### PR TITLE
Support monoio 0.0.9, fix lifetime issues and bump version to 0.0.2

### DIFF
--- a/monoio-http-client/Cargo.toml
+++ b/monoio-http-client/Cargo.toml
@@ -4,12 +4,14 @@ description = "Http client for Monoio."
 edition = "2021"
 license = "MIT/Apache-2.0"
 name = "monoio-http-client"
-version = "0.0.1"
+version = "0.0.2"
 
 [dependencies]
-monoio = {version = "0.0.8"}
-monoio-http = {version = "0.0.1", path = "../monoio-http"}
-monoio-rustls = {version = "0.0.4", default_features = false, features = ["tls12"], optional = true}
+monoio = { version = "0.0.9", path = "../../monoio/monoio" }
+monoio-http = { version = "0.0.2", path = "../monoio-http" }
+monoio-rustls = { version = "0.0.7", path = "../../monoio-tls/monoio-rustls", default_features = false, features = [
+    "tls12",
+], optional = true }
 
 bytes = "1"
 http = "0.2"
@@ -19,14 +21,14 @@ serde_json = "1"
 smol_str = "0.1"
 thiserror = "1"
 
-rustls = {version = "0.20", default-features = false, optional = true}
-tracing = {version = "0.1", optional = true}
-webpki-roots = {version = "0.22", optional = true}
+rustls = { version = "0.20", default-features = false, optional = true }
+tracing = { version = "0.1", optional = true }
+webpki-roots = { version = "0.22", optional = true }
 
 [dev-dependencies]
-serde = {version = "1", features = ["derive"]}
-tracing = {version = "0.1"}
-tracing-subscriber = {version = "0.3"}
+serde = { version = "1", features = ["derive"] }
+tracing = { version = "0.1" }
+tracing-subscriber = { version = "0.3" }
 
 [features]
 default = ["tls", "time"]

--- a/monoio-http-client/src/lib.rs
+++ b/monoio-http-client/src/lib.rs
@@ -1,5 +1,4 @@
 #![allow(stable_features)]
-#![feature(generic_associated_types)]
 #![feature(type_alias_impl_trait)]
 
 mod client;

--- a/monoio-http/Cargo.toml
+++ b/monoio-http/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2021"
 keywords = ["monoio", "http", "async"]
 license = "MIT/Apache-2.0"
 name = "monoio-http"
-version = "0.0.1"
+version = "0.0.2"
 
 [dependencies]
-monoio = {version = "0.0.8"}
-monoio-codec = {version = "0.0.3"}
+monoio = { version = "0.0.9", path = "../../monoio/monoio" }
+monoio-codec = { version = "0.0.4", path = "../../monoio-codec" }
 
 bytes = "1"
 http = "0.2"
@@ -17,5 +17,5 @@ httparse = "1"
 thiserror = "1"
 
 [dev-dependencies]
-serde = {version = "1", features = ["derive"]}
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/monoio-http/src/h1/codec/decoder.rs
+++ b/monoio-http/src/h1/codec/decoder.rs
@@ -413,7 +413,7 @@ where
 {
     type Error = DecodeError;
 
-    type FillPayloadFuture<'a> = impl std::future::Future<Output = Result<(), Self::Error>>
+    type FillPayloadFuture<'a> = impl std::future::Future<Output = Result<(), Self::Error>> + 'a
     where
         Self: 'a;
 
@@ -489,7 +489,7 @@ where
     >,
 {
     type Item = Result<I, DecodeError>;
-    type NextFuture<'a> = impl Future<Output = Option<Self::Item>> where Self: 'a;
+    type NextFuture<'a> = impl Future<Output = Option<Self::Item>> + 'a where Self: 'a;
 
     fn next(&mut self) -> Self::NextFuture<'_> {
         async move {
@@ -688,9 +688,9 @@ mod tests {
     }
 
     impl AsyncReadRent for Mock {
-        type ReadFuture<'a, B> = impl std::future::Future<Output = monoio::BufResult<usize, B>> where
+        type ReadFuture<'a, B> = impl std::future::Future<Output = monoio::BufResult<usize, B>> + 'a where
                 B: monoio::buf::IoBufMut + 'a;
-        type ReadvFuture<'a, B> = impl std::future::Future<Output = monoio::BufResult<usize, B>> where
+        type ReadvFuture<'a, B> = impl std::future::Future<Output = monoio::BufResult<usize, B>> + 'a where
                 B: monoio::buf::IoVecBufMut + 'a;
 
         fn read<T: monoio::buf::IoBufMut>(&mut self, mut buf: T) -> Self::ReadFuture<'_, T> {

--- a/monoio-http/src/h1/codec/encoder.rs
+++ b/monoio-http/src/h1/codec/encoder.rs
@@ -217,14 +217,15 @@ where
     R::Parts: ParamMut<HeaderMap>,
     HeadEncoder: Encoder<R::Parts>,
     <HeadEncoder as Encoder<R::Parts>>::Error: Into<EncodeError>,
+    R: 'static
 {
     type Error = EncodeError;
 
-    type SendFuture<'a> = impl Future<Output = Result<(), Self::Error>> where Self: 'a;
+    type SendFuture<'a> = impl Future<Output = Result<(), Self::Error>> + 'a where Self: 'a;
 
-    type FlushFuture<'a> = impl Future<Output = Result<(), Self::Error>> where Self: 'a;
+    type FlushFuture<'a> = impl Future<Output = Result<(), Self::Error>> + 'a where Self: 'a;
 
-    type CloseFuture<'a> = impl Future<Output = Result<(), Self::Error>> where Self: 'a;
+    type CloseFuture<'a> = impl Future<Output = Result<(), Self::Error>> + 'a where Self: 'a;
 
     fn send(&mut self, item: R) -> Self::SendFuture<'_> {
         let (mut head, payload) = item.into_parts();

--- a/monoio-http/src/h1/payload.rs
+++ b/monoio-http/src/h1/payload.rs
@@ -188,7 +188,7 @@ impl<D, E> StreamInner<D, E> {
 impl<D, E> Stream for StreamPayload<D, E> {
     type Item = Result<D, E>;
 
-    type NextFuture<'a> = impl std::future::Future<Output = Option<Self::Item>> where Self:'a;
+    type NextFuture<'a> = impl std::future::Future<Output = Option<Self::Item>> + 'a where Self:'a;
 
     fn next(&mut self) -> Self::NextFuture<'_> {
         async move {

--- a/monoio-http/src/lib.rs
+++ b/monoio-http/src/lib.rs
@@ -1,5 +1,4 @@
 #![allow(stable_features)]
-#![feature(generic_associated_types)]
 #![feature(type_alias_impl_trait)]
 
 pub trait Param<T> {

--- a/monoio-http/src/util/split.rs
+++ b/monoio-http/src/util/split.rs
@@ -25,9 +25,9 @@ impl<IO> AsyncReadRent for OwnedReadHalf<IO>
 where
     IO: AsyncReadRent,
 {
-    type ReadFuture<'a, B> = impl std::future::Future<Output = monoio::BufResult<usize, B>> where
+    type ReadFuture<'a, B> = impl std::future::Future<Output = monoio::BufResult<usize, B>> + 'a where
         B: IoBufMut + 'a, Self: 'a;
-    type ReadvFuture<'a, B> = impl std::future::Future<Output = monoio::BufResult<usize, B>> where
+    type ReadvFuture<'a, B> = impl std::future::Future<Output = monoio::BufResult<usize, B>> + 'a where
         B: IoVecBufMut + 'a, Self: 'a;
 
     fn read<T: IoBufMut>(&mut self, buf: T) -> Self::ReadFuture<'_, T> {
@@ -47,12 +47,12 @@ impl<IO> AsyncWriteRent for OwnedWriteHalf<IO>
 where
     IO: AsyncWriteRent,
 {
-    type WriteFuture<'a, B> = impl std::future::Future<Output = monoio::BufResult<usize, B>> where
+    type WriteFuture<'a, B> = impl std::future::Future<Output = monoio::BufResult<usize, B>> + 'a where
         B: IoBuf + 'a, Self: 'a;
-    type WritevFuture<'a, B> = impl std::future::Future<Output = monoio::BufResult<usize, B>> where
+    type WritevFuture<'a, B> = impl std::future::Future<Output = monoio::BufResult<usize, B>> + 'a where
         B: IoVecBuf + 'a, Self: 'a;
-    type FlushFuture<'a> = impl std::future::Future<Output = io::Result<()>> where Self: 'a;
-    type ShutdownFuture<'a> = impl std::future::Future<Output = io::Result<()>> where Self: 'a;
+    type FlushFuture<'a> = impl std::future::Future<Output = io::Result<()>> + 'a where Self: 'a;
+    type ShutdownFuture<'a> = impl std::future::Future<Output = io::Result<()>> + 'a where Self: 'a;
 
     fn write<T: IoBuf>(&mut self, buf: T) -> Self::WriteFuture<'_, T> {
         // Submit the write operation


### PR DESCRIPTION
Support monoio 0.0.9, fix lifetime issues and bump version to 0.0.2

```
Finished dev [unoptimized + debuginfo] target(s) in 0.06s
```

```

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

   Doc-tests monoio-http

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests monoio-http-client

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```