### PR TITLE
H2 Payload processing for client

### DIFF
--- a/monoio-http-client/Cargo.toml
+++ b/monoio-http-client/Cargo.toml
@@ -4,7 +4,7 @@ description = "Http client for Monoio."
 edition = "2021"
 license = "MIT/Apache-2.0"
 name = "monoio-http-client"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
 

--- a/monoio-http-client/src/error.rs
+++ b/monoio-http-client/src/error.rs
@@ -21,6 +21,8 @@ pub enum Error {
     Tls(#[from] monoio_rustls::TlsError),
     #[error("serde_json error {0}")]
     Json(#[from] serde_json::Error),
+    #[error("H2 RecvStream decode error {0}")]
+    H2PayloadError(#[from] monoio_http::h2::Error),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/monoio-http/Cargo.toml
+++ b/monoio-http/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 keywords = ["monoio", "http", "async"]
 license = "MIT/Apache-2.0"
 name = "monoio-http"
-version = "0.1.1"
+version = "0.1.2"
 
 [dependencies]
 monoio = { version = "0.1.3" }

--- a/monoio-http/examples/echo_server.rs
+++ b/monoio-http/examples/echo_server.rs
@@ -101,6 +101,7 @@ async fn handle_request(req: Request) -> Response {
             }
         },
         Payload::Stream(_) => unimplemented!(),
+        Payload::H2BodyStream(_) => unimplemented!(),
     };
 
     let status = if has_error {

--- a/monoio-http/src/h1/payload.rs
+++ b/monoio-http/src/h1/payload.rs
@@ -25,6 +25,7 @@ pub enum Payload<D = Bytes, E = PayloadError> {
     None,
     Fixed(FixedPayload<D, E>),
     Stream(StreamPayload<D, E>),
+    H2BodyStream(crate::h2::RecvStream),
 }
 
 pub enum PayloadSender<D, E> {

--- a/monoio-http/src/h2/codec/framed_read.rs
+++ b/monoio-http/src/h2/codec/framed_read.rs
@@ -357,11 +357,13 @@ where
                 } = *self;
 
                 match decode_frame(hpack, max_header_list_size, partial, bytes) {
-                    Ok(frame) => if let Some(frame) = frame {
-                        tracing::debug!(?frame, "received");
-                        return Some(Ok(frame));
-                    },
-                   Err(e) => return Some(Err(e)),
+                    Ok(frame) => {
+                        if let Some(frame) = frame {
+                            tracing::debug!(?frame, "received");
+                            return Some(Ok(frame));
+                        }
+                    }
+                    Err(e) => return Some(Err(e)),
                 }
 
                 // if let Some(frame) = decode_frame(hpack, max_header_list_size, partial, bytes)? {

--- a/monoio-http/src/h2/codec/framed_write.rs
+++ b/monoio-http/src/h2/codec/framed_write.rs
@@ -399,10 +399,10 @@ impl<T, B> FramedWrite<T, B> {
 
 impl<T: AsyncReadRent + Unpin, B> AsyncReadRent for FramedWrite<T, B> {
     type ReadFuture<'a, E> = impl std::future::Future<Output = monoio::BufResult<usize, E>> + 'a where
-    Self: 'a, 
+    Self: 'a,
     E: IoBufMut + 'a;
     type ReadvFuture<'a, E> = impl std::future::Future<Output = monoio::BufResult<usize, E>> + 'a where
-    Self: 'a, 
+    Self: 'a,
     E: IoVecBufMut + 'a;
 
     fn read<F: IoBufMut>(&mut self, buf: F) -> Self::ReadFuture<'_, F> {


### PR DESCRIPTION
- Required to support frontend H2 and backend H1 connection for Monolake
- Piggybacks on existing H1 Payload enum