### PR TITLE
H2 support for client

### DIFF
--- a/monoio-http-client/Cargo.toml
+++ b/monoio-http-client/Cargo.toml
@@ -29,7 +29,6 @@ webpki-roots = { version = "0.23", optional = true }
 native-tls = { version = "0.2", optional = true }
 
 [dev-dependencies]
-monoio-http-client = { path = ".", features = ["logging"]}
 serde = { version = "1", features = ["derive"] }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3" }

--- a/monoio-http-client/Cargo.toml
+++ b/monoio-http-client/Cargo.toml
@@ -29,6 +29,7 @@ webpki-roots = { version = "0.23", optional = true }
 native-tls = { version = "0.2", optional = true }
 
 [dev-dependencies]
+monoio-http-client = { path = ".", features = ["logging"]}
 serde = { version = "1", features = ["derive"] }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3" }

--- a/monoio-http-client/examples/auto_client.rs
+++ b/monoio-http-client/examples/auto_client.rs
@@ -1,0 +1,71 @@
+use http::{request::Builder, Method, Version};
+use monoio_http::common::body::{Body, FixedBody, HttpBody};
+use tracing_subscriber::FmtSubscriber;
+
+#[monoio::main(enable_timer = true)]
+async fn main() {
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(tracing::Level::DEBUG)
+        .finish();
+    // Initialize the tracing subscriber
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("Failed to set up the tracing subscriber");
+
+    // Auto client can support HTTP1 and HTTP2 at the same time.
+    // Looks at the version header to determine the type of connection.
+    // Will default to HTTP1_1
+
+    let h1_client = monoio_http_client::Builder::new().build_auto();
+    let client1 = h1_client.clone();
+    let client2 = h1_client.clone();
+
+    let h = monoio::spawn(async move {
+        for _ in 0..3 {
+            let body = HttpBody::fixed_body(None);
+            let request = Builder::new()
+                .method(Method::GET)
+                .uri("https://httpbin.org/get")
+                .version(Version::HTTP_11)
+                .header(http::header::HOST, "captive.apple.com")
+                .header(http::header::ACCEPT, "*/*")
+                .header(http::header::USER_AGENT, "monoio-http")
+                .body(body)
+                .unwrap();
+
+            tracing::debug!("starting request");
+
+            let resp = client1
+                .send_request(request)
+                .await
+                .expect("Request send failed");
+            let (parts, mut body) = resp.into_parts();
+            println!("{:?}", parts);
+            while let Some(Ok(data)) = body.next_data().await {
+                println!("{:?}", data);
+            }
+        }
+    });
+
+    h.await;
+
+    for _ in 0..3 {
+        let body = HttpBody::fixed_body(None);
+
+        let request = Builder::new()
+            .method(Method::GET)
+            .uri("http://127.0.0.1:8080/")
+            .version(Version::HTTP_2)
+            .body(body)
+            .unwrap();
+
+        let resp = client2
+            .send_request(request)
+            .await
+            .expect("Request send failed");
+        let (parts, mut body) = resp.into_parts();
+        println!("{:?}", parts);
+        while let Some(Ok(data)) = body.next_data().await {
+            println!("{:?}", data);
+        }
+    }
+}

--- a/monoio-http-client/examples/get.rs
+++ b/monoio-http-client/examples/get.rs
@@ -2,9 +2,9 @@ use monoio_http_client::Client;
 
 #[monoio::main(enable_timer = true)]
 async fn main() {
-    let client = Client::new();
+    let client = Client::default();
     let resp = client
-        .get("http://captive.apple.com")
+        .get("https://httpbin.org/get")
         .send()
         .await
         .expect("request fail");

--- a/monoio-http-client/examples/get_json.rs
+++ b/monoio-http-client/examples/get_json.rs
@@ -4,7 +4,7 @@ use monoio_http_client::Client;
 
 #[monoio::main(enable_timer = true)]
 async fn main() {
-    let client = Client::new();
+    let client = Client::default();
     let resp = client
         .get("http://httpbin.org/get")
         .send()

--- a/monoio-http-client/examples/get_json_ssl.rs
+++ b/monoio-http-client/examples/get_json_ssl.rs
@@ -4,7 +4,7 @@ use monoio_http_client::Client;
 
 #[monoio::main(enable_timer = true)]
 async fn main() {
-    let client = Client::new();
+    let client = Client::default();
     let resp = client
         .get("https://httpbin.org/get")
         .send()

--- a/monoio-http-client/examples/h1_client.rs
+++ b/monoio-http-client/examples/h1_client.rs
@@ -1,0 +1,68 @@
+use http::{request::Builder, Method, Version};
+use monoio_http::common::body::{Body, FixedBody, HttpBody};
+use tracing_subscriber::FmtSubscriber;
+
+#[monoio::main(enable_timer = true)]
+async fn main() {
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(tracing::Level::DEBUG)
+        .finish();
+    // Initialize the tracing subscriber
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("Failed to set up the tracing subscriber");
+
+    let h1_client = monoio_http_client::Builder::new().build_http1();
+    let client1 = h1_client.clone();
+    let client2 = h1_client.clone();
+
+    let h = monoio::spawn(async move {
+        let body = HttpBody::fixed_body(None);
+        let request = Builder::new()
+            .method(Method::GET)
+            .uri("https://httpbin.org/get")
+            .version(Version::HTTP_11)
+            .header(http::header::HOST, "captive.apple.com")
+            .header(http::header::ACCEPT, "*/*")
+            .header(http::header::USER_AGENT, "monoio-http")
+            .body(body)
+            .unwrap();
+
+        tracing::debug!("starting request");
+
+        let resp = client1
+            .send_request(request)
+            .await
+            .expect("Request send failed");
+        let (parts, mut body) = resp.into_parts();
+        println!("{:?}", parts);
+        while let Some(Ok(data)) = body.next_data().await {
+            println!("{:?}", data);
+        }
+    });
+
+    for _ in 0..3 {
+        let body = HttpBody::fixed_body(None);
+
+        let request = Builder::new()
+            .method(Method::GET)
+            .uri("https://httpbin.org/html")
+            .version(Version::HTTP_11)
+            .header(http::header::HOST, "captive.apple.com")
+            .header(http::header::ACCEPT, "*/*")
+            .header(http::header::USER_AGENT, "monoio-http")
+            .body(body)
+            .unwrap();
+
+        let resp = client2
+            .send_request(request)
+            .await
+            .expect("Request send failed");
+        let (parts, mut body) = resp.into_parts();
+        println!("{:?}", parts);
+        while let Some(Ok(data)) = body.next_data().await {
+            println!("{:?}", data);
+        }
+    }
+
+    h.await;
+}

--- a/monoio-http-client/examples/h2_client.rs
+++ b/monoio-http-client/examples/h2_client.rs
@@ -1,0 +1,48 @@
+use std::time::Duration;
+
+use http::{request::Builder, Method, Version};
+use monoio::time::sleep;
+use monoio_http::common::body::{Body, FixedBody, HttpBody};
+use tracing_subscriber::FmtSubscriber;
+
+#[monoio::main(enable_timer = true)]
+async fn main() {
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(tracing::Level::DEBUG)
+        .finish();
+    // Initialize the tracing subscriber
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("Failed to set up the tracing subscriber");
+
+    let h2_client = monoio_http_client::Builder::new().build_http2();
+    let mut first = true;
+
+    for _ in 0..6 {
+        if first {
+            sleep(Duration::from_millis(1000)).await;
+            first = false;
+        }
+        let body = HttpBody::fixed_body(None);
+
+        let request = Builder::new()
+            .method(Method::GET)
+            // HTTP Upgrade not supported, requires
+            // a HTTP2 server
+            .uri("http://127.0.0.1:8080/")
+            .version(Version::HTTP_2)
+            .body(body)
+            .unwrap();
+
+        tracing::debug!("starting request");
+
+        let resp = h2_client
+            .send_request(request)
+            .await
+            .expect("Sending request");
+        let (parts, mut body) = resp.into_parts();
+        println!("{:?}", parts);
+        while let Some(Ok(data)) = body.next_data().await {
+            println!("{:?}", data);
+        }
+    }
+}

--- a/monoio-http-client/examples/post_big_json.rs
+++ b/monoio-http-client/examples/post_big_json.rs
@@ -5,7 +5,7 @@ use monoio_http_client::Client;
 
 #[monoio::main(enable_timer = true)]
 async fn main() {
-    let client = Client::new();
+    let client = Client::default();
     let payload = Bytes::from(b"my_payload_data_balabala".repeat(1000));
     let resp = client
         .post("https://httpbin.org/post")

--- a/monoio-http-client/examples/post_json.rs
+++ b/monoio-http-client/examples/post_json.rs
@@ -8,7 +8,7 @@ async fn main() {
         .with_max_level(tracing::Level::DEBUG)
         .init();
 
-    let client = Client::new();
+    let client = Client::default();
     let payload = JsonRequest {
         name: "ihciah".to_string(),
         age: 27,

--- a/monoio-http-client/src/client/connection.rs
+++ b/monoio-http-client/src/client/connection.rs
@@ -1,0 +1,367 @@
+use std::{fmt::Display, future::poll_fn, hash::Hash};
+
+use bytes::Bytes;
+use local_sync::{
+    mpsc::{self, SendError},
+    oneshot,
+};
+use monoio::io::{sink::SinkExt, stream::Stream, AsyncReadRent, AsyncWriteRent, Split};
+use monoio_http::{
+    common::{
+        body::{Body, StreamHint},
+        error::HttpError,
+        request::Request,
+        response::Response,
+    },
+    h1::{codec::ClientCodec, payload::FramedPayloadRecvr},
+    h2::{RecvStream, SendStream},
+};
+
+use super::pool::PooledConnection;
+
+pub struct Transaction<K, B>
+where
+    K: Hash + Eq + Display,
+{
+    pub req: Request<B>,
+    pub resp_tx: oneshot::Sender<crate::Result<Response<B>>>,
+    pub conn: PooledConnection<K, B>,
+}
+
+impl<K, B> Transaction<K, B>
+where
+    K: Hash + Eq + Display,
+{
+    pub fn parts(
+        self,
+    ) -> (
+        Request<B>,
+        oneshot::Sender<crate::Result<Response<B>>>,
+        PooledConnection<K, B>,
+    ) {
+        (self.req, self.resp_tx, self.conn)
+    }
+}
+pub struct SingleRecvr<K, B>
+where
+    K: Hash + Eq + Display,
+{
+    pub req_rx: mpsc::unbounded::Rx<Transaction<K, B>>,
+}
+
+pub struct SingleSender<K, B>
+where
+    K: Hash + Eq + Display,
+{
+    req_tx: mpsc::unbounded::Tx<Transaction<K, B>>,
+}
+
+impl<K, B> SingleSender<K, B>
+where
+    K: Hash + Eq + Display,
+{
+    pub fn into_multi_sender(self) -> MultiSender<K, B> {
+        MultiSender {
+            req_tx: self.req_tx,
+        }
+    }
+
+    // Ideally we should never clone the Single Sender,
+    // but we need a temp sender to handle HTTP1
+    pub fn temp_sender_clone(&self) -> Self {
+        Self {
+            req_tx: self.req_tx.clone(),
+        }
+    }
+
+    pub fn send(&self, item: Transaction<K, B>) -> Result<(), SendError> {
+        self.req_tx.send(item)
+    }
+}
+
+pub struct MultiSender<K, B>
+where
+    K: Hash + Eq + Display,
+{
+    pub req_tx: mpsc::unbounded::Tx<Transaction<K, B>>,
+}
+
+impl<K, B> MultiSender<K, B>
+where
+    K: Hash + Eq + Display,
+{
+    pub fn send(&self, item: Transaction<K, B>) -> Result<(), SendError> {
+        self.req_tx.send(item)
+    }
+}
+
+impl<K, B> Clone for MultiSender<K, B>
+where
+    K: Hash + Eq + Display,
+{
+    fn clone(&self) -> Self {
+        Self {
+            req_tx: self.req_tx.clone(),
+        }
+    }
+}
+pub struct Http1ConnManager<IO: AsyncWriteRent, K, B>
+where
+    K: Hash + Eq + Display,
+{
+    pub req_rx: SingleRecvr<K, B>,
+    pub handle: Option<ClientCodec<IO>>,
+}
+
+const CONN_CLOSE: &[u8] = b"close";
+
+impl<IO, K, B> Http1ConnManager<IO, K, B>
+where
+    IO: AsyncReadRent + AsyncWriteRent + Split,
+    K: Hash + Eq + Display,
+    B: Body<Data = Bytes, Error = HttpError> + From<FramedPayloadRecvr>,
+{
+    pub async fn drive(&mut self) {
+        let mut codec = self.handle.take().unwrap();
+
+        loop {
+            if let Some(t) = self.req_rx.req_rx.recv().await {
+                let (request, resp_tx, mut connection) = t.parts();
+                let (parts, body) = request.into_parts();
+
+                #[cfg(feature = "logging")]
+                tracing::debug!("Response recv on h1 conn {:?}", parts);
+
+                match codec.send_and_flush(Request::from_parts(parts, body)).await {
+                    Ok(_) => match codec.next().await {
+                        Some(Ok(resp)) => {
+                            let (data_tx, data_rx) = local_sync::mpsc::unbounded::channel();
+
+                            let header_value = resp.headers().get(http::header::CONNECTION);
+                            let reuse_conn = match header_value {
+                                Some(v) => !v.as_bytes().eq_ignore_ascii_case(CONN_CLOSE),
+                                None => resp.version() != http::Version::HTTP_10,
+                            };
+                            connection.set_reuseable(reuse_conn);
+
+                            let (parts, body_builder) = resp.into_parts();
+                            let mut framed_payload = body_builder.with_io(codec);
+                            let framed_payload_rcvr = FramedPayloadRecvr {
+                                data_rx,
+                                hint: framed_payload.stream_hint(),
+                            };
+
+                            #[cfg(feature = "logging")]
+                            tracing::debug!("Sending reply back from conn manager {:?}", parts);
+
+                            let resp = Response::from_parts(parts, B::from(framed_payload_rcvr));
+                            let _ = resp_tx.send(Ok(resp));
+
+                            while let Some(r) = framed_payload.next_data().await {
+                                let _ = data_tx.send(Some(r));
+                            }
+
+                            // At this point we have streamed the payload and the codec can be
+                            // reused. Drop the connection, which will
+                            // add it back to the pool.
+
+                            drop(connection);
+                            codec = framed_payload.get_source();
+                        }
+                        Some(Err(e)) => {
+                            #[cfg(feature = "logging")]
+                            tracing::error!("decode upstream response error {:?}", e);
+                            connection.set_reuseable(false);
+                            let _ = resp_tx.send(Err(crate::Error::H1Decode(e)));
+                            break;
+                        }
+                        None => {
+                            #[cfg(feature = "logging")]
+                            tracing::error!("upstream return eof");
+                            connection.set_reuseable(false);
+                            let _ = resp_tx.send(Err(crate::Error::Io(std::io::Error::new(
+                                std::io::ErrorKind::UnexpectedEof,
+                                "unexpected eof when read response",
+                            ))));
+                            break;
+                        }
+                    },
+                    Err(e) => {
+                        #[cfg(feature = "logging")]
+                        tracing::error!("send upstream request error {:?}", e);
+                        connection.set_reuseable(false);
+                        let _ = resp_tx.send(Err(e.into()));
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+pub struct StreamTask<B: Body> {
+    stream_pipe: SendStream<Bytes>,
+    body: B,
+    data_done: bool,
+}
+
+impl<B: Body<Data = Bytes>> StreamTask<B> {
+    fn new(stream_pipe: SendStream<Bytes>, body: B) -> Self {
+        Self {
+            stream_pipe,
+            body,
+            data_done: false,
+        }
+    }
+    async fn drive(&mut self) {
+        loop {
+            if !self.data_done {
+                // we don't have the next chunk of data yet, so just reserve 1 byte to make
+                // sure there's some capacity available. h2 will handle the capacity management
+                // for the actual body chunk.
+                self.stream_pipe.reserve_capacity(1);
+
+                if self.stream_pipe.capacity() == 0 {
+                    loop {
+                        let cap = poll_fn(|cx| self.stream_pipe.poll_capacity(cx)).await;
+                        match cap {
+                            Some(Ok(0)) => {}
+                            Some(Ok(_)) => break,
+                            Some(Err(_e)) => {
+                                return;
+                                // return Poll::Ready(Err(crate::Error::new_body_write(e)))
+                            }
+                            None => {
+                                // None means the stream is no longer in a
+                                // streaming state, we either finished it
+                                // somehow, or the remote reset us.
+                                // return Poll::Ready(Err(crate::Error::new_body_write(
+                                //     "send stream capacity unexpectedly closed",
+                                // )));
+                                return;
+                            }
+                        }
+                    }
+                } else {
+                    let stream_rst = poll_fn(|cx| match self.stream_pipe.poll_reset(cx) {
+                        std::task::Poll::Pending => std::task::Poll::Ready(false),
+                        std::task::Poll::Ready(_) => std::task::Poll::Ready(true),
+                    })
+                    .await;
+
+                    if stream_rst {
+                        // debug!("stream received RST_STREAM: {:?}", reason);
+                        // return Poll::Ready(Err(crate::Error::new_body_write(::h2::Error::from(
+                        //     reason,
+                        // ))));
+                        return;
+                    }
+                }
+
+                match self.body.stream_hint() {
+                    StreamHint::None => {
+                        let _ = self.stream_pipe.send_data(Bytes::new(), true);
+                        self.data_done = true;
+                        #[cfg(feature = "logging")]
+                        tracing::debug!("H2 Stream task is done ");
+                    }
+                    StreamHint::Fixed => {
+                        if let Some(Ok(data)) = self.body.next_data().await {
+                            let _ = self.stream_pipe.send_data(data, true);
+                            self.data_done = true;
+                        }
+                    }
+                    StreamHint::Stream => {
+                        if let Some(Ok(data)) = self.body.next_data().await {
+                            let _ = self.stream_pipe.send_data(data, false);
+                        } else {
+                            let _ = self.stream_pipe.send_data(Bytes::new(), true);
+                            self.data_done = true;
+                        }
+                    }
+                }
+            } else {
+                let stream_rst = poll_fn(|cx| match self.stream_pipe.poll_reset(cx) {
+                    std::task::Poll::Pending => std::task::Poll::Ready(false),
+                    std::task::Poll::Ready(_) => std::task::Poll::Ready(true),
+                })
+                .await;
+
+                if stream_rst {
+                    // debug!("stream received RST_STREAM: {:?}", reason);
+                    // return Poll::Ready(Err(crate::Error::new_body_write(::h2::Error::from(
+                    //     reason,
+                    // ))));
+                    return;
+                }
+                break;
+                // TODO: Handle trailer
+            }
+        }
+    }
+}
+
+pub struct Http2ConnManager<K: Hash + Eq + Display, B> {
+    pub req_rx: SingleRecvr<K, B>,
+    pub handle: monoio_http::h2::client::SendRequest<bytes::Bytes>,
+}
+
+impl<K, B> Http2ConnManager<K, B>
+where
+    K: Hash + Eq + Display,
+    B: Body<Data = Bytes> + From<RecvStream> + 'static,
+{
+    pub async fn drive(&mut self) {
+        while let Some(t) = self.req_rx.req_rx.recv().await {
+            let (request, resp_tx, mut connection) = t.parts();
+            let (parts, body) = request.into_parts();
+            #[cfg(feature = "logging")]
+            tracing::debug!("H2 conn manager recv request {:?}", parts);
+
+            let request = http::request::Request::from_parts(parts, ());
+            let handle = self.handle.clone();
+            let mut ready_handle = handle.ready().await.unwrap();
+
+            let (resp_fut, send_stream) = match ready_handle.send_request(request, false) {
+                Ok(ok) => ok,
+                Err(e) => {
+                    #[cfg(feature = "logging")]
+                    tracing::debug!("client send request error: {}", e);
+                    let _ = resp_tx.send(Err(e.into()));
+                    break;
+                }
+            };
+
+            #[cfg(feature = "logging")]
+            tracing::debug!("H2 conn manager sent request to server");
+
+            monoio::spawn(async move {
+                let mut stream_task = StreamTask::new(send_stream, body);
+                stream_task.drive().await;
+            });
+
+            monoio::spawn(async move {
+                match resp_fut.await {
+                    Ok(resp) => {
+                        let (parts, body) = resp.into_parts();
+                        #[cfg(feature = "logging")]
+                        tracing::debug!("Response from server {:?}", parts);
+                        let ret_resp = Response::from_parts(parts, B::from(body));
+                        let _ = resp_tx.send(Ok(ret_resp));
+                    }
+                    Err(e) => {
+                        #[cfg(feature = "logging")]
+                        tracing::debug!("Response future returned error {:?}", e);
+                        let _ = resp_tx.send(Err(e.into()));
+                    }
+                }
+            });
+        }
+    }
+}
+
+pub fn request_channel<K: Hash + Eq + Display, B>() -> (SingleSender<K, B>, SingleRecvr<K, B>) {
+    let (req_tx, req_rx) = mpsc::unbounded::channel();
+    (SingleSender { req_tx }, SingleRecvr { req_rx })
+}

--- a/monoio-http-client/src/client/key.rs
+++ b/monoio-http-client/src/client/key.rs
@@ -124,11 +124,11 @@ impl ParamMut<String> for Key {
 #[derive(ThisError, Debug)]
 pub enum FromUriError {
     #[cfg(feature = "rustls")]
-    #[error("invalid dns name")]
+    #[error("Invalid dns name")]
     InvalidDnsName(#[from] rustls::client::InvalidDnsNameError),
-    #[error("scheme not support")]
+    #[error("Scheme not supported")]
     UnsupportScheme,
-    #[error("no authority in uri")]
+    #[error("Missing authority in uri")]
     NoAuthority,
 }
 

--- a/monoio-http-client/src/client/pool.rs
+++ b/monoio-http-client/src/client/pool.rs
@@ -1,10 +1,9 @@
 use std::{
     cell::UnsafeCell,
     collections::{HashMap, VecDeque},
-    fmt::Debug,
+    fmt::{Debug, Display},
     future::Future,
     hash::Hash,
-    ops::{Deref, DerefMut},
     rc::{Rc, Weak},
     task::ready,
     time::{Duration, Instant},
@@ -17,25 +16,27 @@ const DEFAULT_POOL_SIZE: usize = 32;
 // https://datatracker.ietf.org/doc/html/rfc6335
 const MAX_KEEPALIVE_CONNS: usize = 16384;
 
-use monoio::io::{sink::Sink, AsyncWriteRent};
-use monoio_http::h1::{codec::ClientCodec, BorrowFramedRead, FramedRead};
+use local_sync::oneshot;
+use monoio_http::common::request::Request;
 
-type Conns<K, IO> = Rc<UnsafeCell<SharedInner<K, IO>>>;
-type WeakConns<K, IO> = Weak<UnsafeCell<SharedInner<K, IO>>>;
+use super::connection::{MultiSender, SingleSender, Transaction};
 
-struct IdleCodec<IO: AsyncWriteRent> {
-    codec: ClientCodec<IO>,
+type Conns<K, B> = Rc<UnsafeCell<SharedInner<K, B>>>;
+type WeakConns<K, B> = Weak<UnsafeCell<SharedInner<K, B>>>;
+
+struct IdleConnection<K: Hash + Eq + Display, B> {
+    pipe: PooledConnectionPipe<K, B>,
     idle_at: Instant,
 }
 
-struct SharedInner<K, IO: AsyncWriteRent> {
-    mapping: HashMap<K, VecDeque<IdleCodec<IO>>>,
+struct SharedInner<K: Hash + Eq + Display, B> {
+    mapping: HashMap<K, VecDeque<IdleConnection<K, B>>>,
     max_idle: usize,
     #[cfg(feature = "time")]
     _drop: local_sync::oneshot::Receiver<()>,
 }
 
-impl<K, IO: AsyncWriteRent> SharedInner<K, IO> {
+impl<K: Hash + Eq + Display, B> SharedInner<K, B> {
     #[cfg(feature = "time")]
     fn new(max_idle: Option<usize>) -> (local_sync::oneshot::Sender<()>, Self) {
         let mapping = HashMap::with_capacity(DEFAULT_POOL_SIZE);
@@ -76,11 +77,11 @@ impl<K, IO: AsyncWriteRent> SharedInner<K, IO> {
 
 // TODO: Connection leak? Maybe remove expired connection periodically.
 #[derive(Debug)]
-pub struct ConnectionPool<K: Hash + Eq, IO: AsyncWriteRent> {
-    conns: Conns<K, IO>,
+pub struct ConnectionPool<K: Hash + Eq + Display, B> {
+    conns: Conns<K, B>,
 }
 
-impl<K: Hash + Eq, IO: AsyncWriteRent> Clone for ConnectionPool<K, IO> {
+impl<K: Hash + Eq + Display, B> Clone for ConnectionPool<K, B> {
     fn clone(&self) -> Self {
         Self {
             conns: self.conns.clone(),
@@ -88,20 +89,7 @@ impl<K: Hash + Eq, IO: AsyncWriteRent> Clone for ConnectionPool<K, IO> {
     }
 }
 
-pub struct PooledConnection<K, IO: AsyncWriteRent>
-where
-    K: Hash + Eq + Debug,
-{
-    // option is for take when drop
-    key: Option<K>,
-    // option is for take when drop
-    codec: Option<ClientCodec<IO>>,
-
-    pool: WeakConns<K, IO>,
-    reuseable: bool,
-}
-
-impl<K: Hash + Eq + 'static, IO: AsyncWriteRent + 'static> ConnectionPool<K, IO> {
+impl<K: Hash + Eq + Display + 'static, B: 'static> ConnectionPool<K, B> {
     #[cfg(feature = "time")]
     fn new(idle_interval: Option<Duration>, max_idle: Option<usize>) -> Self {
         let (tx, inner) = SharedInner::new(max_idle);
@@ -124,7 +112,7 @@ impl<K: Hash + Eq + 'static, IO: AsyncWriteRent + 'static> ConnectionPool<K, IO>
     }
 }
 
-impl<K: Hash + Eq + 'static, IO: AsyncWriteRent + 'static> Default for ConnectionPool<K, IO> {
+impl<K: Hash + Eq + Display + 'static, B: 'static> Default for ConnectionPool<K, B> {
     #[cfg(feature = "time")]
     fn default() -> Self {
         Self::new(None, None)
@@ -136,96 +124,51 @@ impl<K: Hash + Eq + 'static, IO: AsyncWriteRent + 'static> Default for Connectio
     }
 }
 
-impl<K, IO: AsyncWriteRent> PooledConnection<K, IO>
+pub struct PooledConnection<K, B>
 where
-    K: Hash + Eq + Debug,
+    K: Hash + Eq + Display,
 {
-    pub fn set_reuseable(&mut self, reuseable: bool) {
-        self.reuseable = reuseable;
+    // option is for take when drop
+    key: Option<K>,
+    pipe: Option<PooledConnectionPipe<K, B>>,
+    pool: WeakConns<K, B>,
+    reuseable: bool,
+}
+
+impl<K, B> PooledConnection<K, B>
+where
+    K: Hash + Eq + Display,
+{
+    pub async fn send_request(
+        mut self,
+        req: Request<B>,
+    ) -> Result<http::Response<B>, crate::Error> {
+        match self.pipe.take() {
+            Some(mut pipe) => {
+                self.pipe = Some(pipe.clone());
+                match pipe.send_request(req, self).await {
+                    Ok(resp) => Ok(resp),
+                    Err(e) => {
+                        #[cfg(feature = "logging")]
+                        tracing::error!("Request failed: {:?}", e);
+                        Err(e)
+                    }
+                }
+            }
+            None => {
+                panic!()
+            }
+        }
+    }
+
+    pub fn set_reuseable(&mut self, set: bool) {
+        self.reuseable = set;
     }
 }
 
-impl<K: Hash + Eq + Debug, IO: AsyncWriteRent> BorrowFramedRead for PooledConnection<K, IO>
+impl<K, IO> Drop for PooledConnection<K, IO>
 where
-    ClientCodec<IO>: BorrowFramedRead,
-{
-    type IO = <ClientCodec<IO> as BorrowFramedRead>::IO;
-    type Codec = <ClientCodec<IO> as BorrowFramedRead>::Codec;
-
-    fn framed_mut(&mut self) -> &mut FramedRead<Self::IO, Self::Codec> {
-        self.codec
-            .as_mut()
-            .expect("connection should be present")
-            .framed_mut()
-    }
-}
-
-impl<K, IO: AsyncWriteRent> Deref for PooledConnection<K, IO>
-where
-    K: Hash + Eq + Debug,
-{
-    type Target = ClientCodec<IO>;
-
-    fn deref(&self) -> &Self::Target {
-        self.codec.as_ref().expect("connection should be present")
-    }
-}
-
-impl<K, IO: AsyncWriteRent> DerefMut for PooledConnection<K, IO>
-where
-    K: Hash + Eq + Debug,
-{
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.codec.as_mut().expect("connection should be present")
-    }
-}
-
-impl<K: Hash + Eq + Debug, IO: AsyncWriteRent, R> Sink<R> for PooledConnection<K, IO>
-where
-    ClientCodec<IO>: Sink<R>,
-{
-    type Error = <ClientCodec<IO> as Sink<R>>::Error;
-
-    type SendFuture<'a> = <ClientCodec<IO> as Sink<R>>::SendFuture<'a>
-    where
-        Self: 'a, R: 'a;
-
-    type FlushFuture<'a> = <ClientCodec<IO> as Sink<R>>::FlushFuture<'a>
-    where
-        Self: 'a;
-
-    type CloseFuture<'a> = <ClientCodec<IO> as Sink<R>>::CloseFuture<'a>
-    where
-        Self: 'a;
-
-    fn send<'a>(&'a mut self, item: R) -> Self::SendFuture<'a>
-    where
-        R: 'a,
-    {
-        self.codec
-            .as_mut()
-            .expect("connection should be present")
-            .send(item)
-    }
-
-    fn flush(&mut self) -> Self::FlushFuture<'_> {
-        self.codec
-            .as_mut()
-            .expect("connection should be present")
-            .flush()
-    }
-
-    fn close(&mut self) -> Self::CloseFuture<'_> {
-        self.codec
-            .as_mut()
-            .expect("connection should be present")
-            .close()
-    }
-}
-
-impl<K, IO: AsyncWriteRent> Drop for PooledConnection<K, IO>
-where
-    K: Hash + Eq + Debug,
+    K: Hash + Eq + Display,
 {
     fn drop(&mut self) {
         if !self.reuseable {
@@ -236,16 +179,15 @@ where
 
         if let Some(pool) = self.pool.upgrade() {
             let key = self.key.take().expect("unable to take key");
-            let codec = self.codec.take().expect("unable to take connection");
-            let idle = IdleCodec {
-                codec,
+            let pipe = self.pipe.take().expect("unable to take connection");
+            let idle = IdleConnection {
+                pipe,
                 idle_at: Instant::now(),
             };
 
             let conns = unsafe { &mut *pool.get() };
             #[cfg(feature = "logging")]
-            let key_debug = format!("{key:?}");
-
+            let key_str = key.to_string();
             let queue = conns
                 .mapping
                 .entry(key)
@@ -253,13 +195,14 @@ where
 
             #[cfg(feature = "logging")]
             tracing::debug!(
-                "connection pool size: {:?} for key: {key_debug}",
+                "connection pool size: {:?} for key: {:?}",
                 queue.len(),
+                key_str
             );
 
             if queue.len() > conns.max_idle {
                 #[cfg(feature = "logging")]
-                tracing::info!("connection pool is full for key: {key_debug}");
+                tracing::info!("connection pool is full for key: {:?}", key_str);
                 let _ = queue.pop_front();
             }
 
@@ -271,38 +214,54 @@ where
     }
 }
 
-impl<K, IO: AsyncWriteRent> ConnectionPool<K, IO>
+impl<K, B> ConnectionPool<K, B>
 where
-    K: Hash + Eq + ToOwned<Owned = K> + Debug,
+    K: Hash + Eq + ToOwned<Owned = K> + Display,
 {
-    pub fn get(&self, key: &K) -> Option<PooledConnection<K, IO>> {
+    pub fn get(&self, key: &K) -> Option<PooledConnection<K, B>> {
         let conns = unsafe { &mut *self.conns.get() };
 
         match conns.mapping.get_mut(key) {
             Some(v) => {
                 #[cfg(feature = "logging")]
-                tracing::debug!("connection got from pool for key: {key:?}");
-                v.pop_front().map(|idle| PooledConnection {
+                tracing::debug!("connection got from pool for key: {:?} ", key.to_string());
+                let mut pooled_conn = PooledConnection {
                     key: Some(key.to_owned()),
-                    codec: Some(idle.codec),
+                    pipe: None,
                     pool: Rc::downgrade(&self.conns),
                     reuseable: true,
-                })
+                };
+                let idle_conn = v.pop_front();
+                match idle_conn {
+                    Some(mut idle) => {
+                        let is_h2 = idle.pipe.is_http2();
+                        if is_h2 {
+                            pooled_conn.pipe = Some(idle.pipe.clone());
+                            pooled_conn.reuseable = false;
+                            idle.idle_at = Instant::now();
+                            v.push_back(idle);
+                        } else {
+                            pooled_conn.pipe = Some(idle.pipe);
+                        }
+                        Some(pooled_conn)
+                    }
+                    None => None,
+                }
             }
             None => {
                 #[cfg(feature = "logging")]
-                tracing::debug!("no connection in pool for key: {key:?}");
+                tracing::debug!("no connection in pool for key: {:?} ", key.to_string());
                 None
             }
         }
     }
 
-    pub fn link(&self, key: K, io: ClientCodec<IO>) -> PooledConnection<K, IO> {
+    pub fn link(&self, key: K, pipe: PooledConnectionPipe<K, B>) -> PooledConnection<K, B> {
         #[cfg(feature = "logging")]
         tracing::debug!("linked new connection to the pool");
         PooledConnection {
             key: Some(key),
-            codec: Some(io),
+            pipe: Some(pipe),
             pool: Rc::downgrade(&self.conns),
             reuseable: true,
         }
@@ -310,14 +269,14 @@ where
 }
 
 // TODO: make interval not eq to idle_dur
-struct IdleTask<K, IO: AsyncWriteRent> {
+struct IdleTask<K: Hash + Eq + Display, B> {
     tx: local_sync::oneshot::Sender<()>,
-    conns: WeakConns<K, IO>,
+    conns: WeakConns<K, B>,
     interval: monoio::time::Interval,
     idle_dur: Duration,
 }
 
-impl<K, IO: AsyncWriteRent> Future for IdleTask<K, IO> {
+impl<K: Hash + Eq + Display, B> Future for IdleTask<K, B> {
     type Output = ();
 
     fn poll(
@@ -346,6 +305,55 @@ impl<K, IO: AsyncWriteRent> Future for IdleTask<K, IO> {
             #[cfg(feature = "logging")]
             tracing::debug!("pool upgrade failed, idle task exit");
             return std::task::Poll::Ready(());
+        }
+    }
+}
+pub enum PooledConnectionPipe<K, B>
+where
+    K: Hash + Eq + Display,
+{
+    Http1(SingleSender<K, B>),
+    Http2(MultiSender<K, B>),
+}
+
+impl<K: Hash + Eq + Display, B> PooledConnectionPipe<K, B> {
+    pub async fn send_request(
+        &mut self,
+        req: Request<B>,
+        conn: PooledConnection<K, B>,
+    ) -> Result<http::Response<B>, crate::Error> {
+        let (resp_tx, resp_rx) = oneshot::channel();
+
+        let res = match self {
+            Self::Http1(ref s) => s.send(Transaction { req, resp_tx, conn }),
+            Self::Http2(ref s) => s.send(Transaction { req, resp_tx, conn }),
+        };
+
+        match res {
+            Ok(_) => {}
+            Err(e) => {
+                #[cfg(feature = "logging")]
+                tracing::error!("Request send to conn manager failed {:?}", e);
+                return Err(crate::error::Error::ConnManagerReqSendError);
+            }
+        }
+
+        resp_rx.await?
+    }
+
+    pub fn is_http2(&self) -> bool {
+        match self {
+            Self::Http1(_) => false,
+            Self::Http2(_) => true,
+        }
+    }
+}
+
+impl<K: Hash + Eq + Display, B> Clone for PooledConnectionPipe<K, B> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Http1(tx) => Self::Http1(tx.temp_sender_clone()),
+            Self::Http2(tx) => Self::Http2(tx.clone()),
         }
     }
 }

--- a/monoio-http-client/src/client/pool.rs
+++ b/monoio-http-client/src/client/pool.rs
@@ -17,7 +17,7 @@ const DEFAULT_POOL_SIZE: usize = 32;
 const MAX_KEEPALIVE_CONNS: usize = 16384;
 
 use local_sync::oneshot;
-use monoio_http::common::request::Request;
+use monoio_http::common::{body::HttpBody, request::Request};
 
 use super::connection::{MultiSender, SingleSender, Transaction};
 
@@ -142,7 +142,7 @@ where
     pub async fn send_request(
         mut self,
         req: Request<B>,
-    ) -> Result<http::Response<B>, crate::Error> {
+    ) -> Result<http::Response<HttpBody>, crate::Error> {
         match self.pipe.take() {
             Some(mut pipe) => {
                 self.pipe = Some(pipe.clone());
@@ -321,7 +321,7 @@ impl<K: Hash + Eq + Display, B> PooledConnectionPipe<K, B> {
         &mut self,
         req: Request<B>,
         conn: PooledConnection<K, B>,
-    ) -> Result<http::Response<B>, crate::Error> {
+    ) -> Result<http::Response<HttpBody>, crate::Error> {
         let (resp_tx, resp_rx) = oneshot::channel();
 
         let res = match self {

--- a/monoio-http-client/src/error.rs
+++ b/monoio-http-client/src/error.rs
@@ -7,9 +7,9 @@ pub enum Error {
     #[error("http header error")]
     Http(#[from] http::Error),
     #[error("encode error {0}")]
-    Encode(#[from] monoio_http::h1::codec::encoder::EncodeError),
+    H1Encode(#[from] monoio_http::h1::codec::encoder::EncodeError),
     #[error("decode error {0}")]
-    Decode(#[from] monoio_http::h1::codec::decoder::DecodeError),
+    H1Decode(#[from] monoio_http::h1::codec::decoder::DecodeError),
     #[error("receive body error {0}")]
     Payload(#[from] monoio_http::h1::payload::PayloadError),
     #[error("io error {0}")]
@@ -22,8 +22,16 @@ pub enum Error {
     NativeTls(#[from] monoio_native_tls::TlsError),
     #[error("serde_json error {0}")]
     Json(#[from] serde_json::Error),
-    #[error("H2 RecvStream decode error {0}")]
-    H2PayloadError(#[from] monoio_http::h2::Error),
+    #[error("H2 error {0}")]
+    H2Error(#[from] monoio_http::h2::Error),
+    #[error("Resp Recv from connection manager failed {0}")]
+    ConnManagerRespRecvError(#[from] local_sync::oneshot::error::RecvError),
+    #[error("Recv from conn manager failed")]
+    ConnManagerReqSendError,
+    #[error("Conn Manager marked this conn for close")]
+    ClosePooledConnection,
+    #[error("Http crate error {0}")]
+    HttpError(#[from] monoio_http::common::error::HttpError),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/monoio-http-client/src/error.rs
+++ b/monoio-http-client/src/error.rs
@@ -6,12 +6,8 @@ pub enum Error {
     FromUri(#[from] crate::client::key::FromUriError),
     #[error("http header error")]
     Http(#[from] http::Error),
-    #[error("encode error {0}")]
-    H1Encode(#[from] monoio_http::h1::codec::encoder::EncodeError),
     #[error("decode error {0}")]
     H1Decode(#[from] monoio_http::h1::codec::decoder::DecodeError),
-    #[error("receive body error {0}")]
-    Payload(#[from] monoio_http::h1::payload::PayloadError),
     #[error("io error {0}")]
     Io(#[from] std::io::Error),
     #[cfg(feature = "rustls")]

--- a/monoio-http-client/src/lib.rs
+++ b/monoio-http-client/src/lib.rs
@@ -6,7 +6,7 @@ mod error;
 mod request;
 mod response;
 
-pub use client::{connector::Connector, Client, ClientConfig};
+pub use client::{connector::Connector, Builder, Client, ClientConfig};
 pub use error::{Error, Result};
 pub use request::ClientRequest;
 pub use response::ClientResponse;

--- a/monoio-http-client/src/request.rs
+++ b/monoio-http-client/src/request.rs
@@ -1,6 +1,13 @@
 use bytes::Bytes;
 use http::{header::HeaderName, request::Builder, HeaderValue, Method, Uri};
-use monoio_http::h1::payload::{fixed_payload_pair, Payload};
+use monoio_http::{
+    common::{
+        body::{Body, FixedBody, HttpBody},
+        error::HttpError,
+    },
+    h1::payload::FramedPayloadRecvr,
+    h2::RecvStream,
+};
 
 #[cfg(any(feature = "rustls", feature = "native-tls"))]
 use crate::client::connector::DefaultTlsConnector;
@@ -10,13 +17,13 @@ use crate::{
 };
 
 #[cfg(any(feature = "rustls", feature = "native-tls"))]
-pub struct ClientRequest<C = DefaultTcpConnector<Key>, CS = DefaultTlsConnector<Key>> {
-    client: Client<C, CS>,
+pub struct ClientRequest<B, C = DefaultTcpConnector<Key, B>, CS = DefaultTlsConnector<Key, B>> {
+    client: Client<B, C, CS>,
     builder: Builder,
 }
 
 #[cfg(not(any(feature = "rustls", feature = "native-tls")))]
-pub struct ClientRequest<C = DefaultTcpConnector<Key>> {
+pub struct ClientRequest<B, C = DefaultTcpConnector<Key>> {
     client: Client<C>,
     builder: Builder,
 }
@@ -24,19 +31,19 @@ pub struct ClientRequest<C = DefaultTcpConnector<Key>> {
 macro_rules! client_request_impl {
     ( $( $x:item )* ) => {
         #[cfg(not(any(feature = "rustls", feature = "native-tls")))]
-        impl<C> ClientRequest<C> {
+        impl<B, C> ClientRequest<B, C> {
             $($x)*
         }
 
         #[cfg(any(feature = "rustls", feature = "native-tls"))]
-        impl<C, CS> ClientRequest<C, CS> {
+        impl<B, C, CS> ClientRequest<B, C, CS> {
             $($x)*
         }
     };
 }
 
 client_request_impl! {
-    pub fn new(client: Client<C, CS>) -> Self {
+    pub fn new(client: Client<B, C, CS> ) -> Self {
         Self {
             client,
             builder: Builder::new(),
@@ -72,7 +79,7 @@ client_request_impl! {
         self
     }
 
-    fn build_request(builder: Builder, body: Payload) -> crate::Result<http::Request<Payload>> {
+    fn build_request(builder: Builder, body: B) -> crate::Result<http::Request<B>> {
         let mut req = builder.version(http::Version::HTTP_11).body(body)?;
         if let Some(host) = req.uri().host() {
             let host = HeaderValue::try_from(host).map_err(http::Error::from)?;
@@ -85,31 +92,38 @@ client_request_impl! {
     }
 }
 
-impl ClientRequest {
-    pub async fn send(self) -> crate::Result<ClientResponse> {
-        let request = Self::build_request(self.builder, Payload::None)?;
-        let resp = self.client.send(request).await?;
+impl<B> ClientRequest<B>
+where
+    B: Body<Data = Bytes, Error = HttpError>
+        + From<RecvStream>
+        + From<FramedPayloadRecvr>
+        + 'static
+        + FixedBody<BodyType = B>,
+    HttpBody: From<B>,
+{
+    pub async fn send(self) -> crate::Result<ClientResponse<B>> {
+        let request = Self::build_request(self.builder, B::fixed_body(None))?;
+        let resp = self.client.send_request(request).await?;
         Ok(ClientResponse::new(resp))
     }
 
-    pub async fn send_body(self, data: Bytes) -> crate::Result<ClientResponse> {
-        let (payload, payload_sender) = fixed_payload_pair();
-        payload_sender.feed(Ok(data));
-        let request = Self::build_request(self.builder, Payload::Fixed(payload))?;
-        let resp = self.client.send(request).await?;
+    pub async fn send_body(self, data: Bytes) -> crate::Result<ClientResponse<B>> {
+        let request = Self::build_request(self.builder, B::fixed_body(Some(data)))?;
+        let resp = self.client.send_request(request).await?;
         Ok(ClientResponse::new(resp))
     }
 
-    pub async fn send_json<T: serde::Serialize>(self, data: &T) -> crate::Result<ClientResponse> {
+    pub async fn send_json<T: serde::Serialize>(
+        self,
+        data: &T,
+    ) -> crate::Result<ClientResponse<B>> {
         let body: Bytes = serde_json::to_vec(data)?.into();
         let builder = self.builder.header(
             http::header::CONTENT_TYPE,
             HeaderValue::from_static("application/json"),
         );
-        let (payload, payload_sender) = fixed_payload_pair();
-        payload_sender.feed(Ok(body));
-        let request = Self::build_request(builder, Payload::Fixed(payload))?;
-        let resp = self.client.send(request).await?;
+        let request = Self::build_request(builder, B::fixed_body(Some(body)))?;
+        let resp = self.client.send_request(request).await?;
         Ok(ClientResponse::new(resp))
     }
 }

--- a/monoio-http-client/src/response.rs
+++ b/monoio-http-client/src/response.rs
@@ -1,11 +1,11 @@
 use bytes::{Bytes, BytesMut};
 use http::{Extensions, HeaderMap, HeaderValue, StatusCode, Version};
-use monoio_http::{
-    common::body::{Body, StreamHint},
-    h1::payload::BoxedFramedPayload,
+use monoio_http::common::{
+    body::{Body, StreamHint},
+    error::HttpError,
 };
 
-pub struct ClientResponse {
+pub struct ClientResponse<B> {
     /// The response's status
     status: StatusCode,
     /// The response's version
@@ -15,11 +15,11 @@ pub struct ClientResponse {
     /// The response's extensions
     extensions: Extensions,
     /// Payload
-    body: BoxedFramedPayload,
+    body: B,
 }
 
-impl ClientResponse {
-    pub fn new(inner: http::Response<BoxedFramedPayload>) -> Self {
+impl<B: Body<Data = Bytes, Error = HttpError>> ClientResponse<B> {
+    pub fn new(inner: http::Response<B>) -> Self {
         let (head, body) = inner.into_parts();
         Self {
             status: head.status,
@@ -79,7 +79,7 @@ impl ClientResponse {
     }
 
     /// Get raw body(Payload).
-    pub fn raw_body(self) -> BoxedFramedPayload {
+    pub fn raw_body(self) -> B {
         self.body
     }
 

--- a/monoio-http-client/src/response.rs
+++ b/monoio-http-client/src/response.rs
@@ -1,11 +1,8 @@
 use bytes::{Bytes, BytesMut};
 use http::{Extensions, HeaderMap, HeaderValue, StatusCode, Version};
-use monoio_http::common::{
-    body::{Body, StreamHint},
-    error::HttpError,
-};
+use monoio_http::common::body::{Body, HttpBody, StreamHint};
 
-pub struct ClientResponse<B> {
+pub struct ClientResponse {
     /// The response's status
     status: StatusCode,
     /// The response's version
@@ -15,11 +12,11 @@ pub struct ClientResponse<B> {
     /// The response's extensions
     extensions: Extensions,
     /// Payload
-    body: B,
+    body: HttpBody,
 }
 
-impl<B: Body<Data = Bytes, Error = HttpError>> ClientResponse<B> {
-    pub fn new(inner: http::Response<B>) -> Self {
+impl ClientResponse {
+    pub fn new(inner: http::Response<HttpBody>) -> Self {
         let (head, body) = inner.into_parts();
         Self {
             status: head.status,
@@ -79,7 +76,7 @@ impl<B: Body<Data = Bytes, Error = HttpError>> ClientResponse<B> {
     }
 
     /// Get raw body(Payload).
-    pub fn raw_body(self) -> B {
+    pub fn raw_body(self) -> HttpBody {
         self.body
     }
 

--- a/monoio-http/Cargo.toml
+++ b/monoio-http/Cargo.toml
@@ -18,6 +18,7 @@ http = "0.2"
 httparse = "1"
 thiserror = "1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
+local-sync = "0.1"
 
 async-stream = "0.3.5"
 

--- a/monoio-http/examples/echo_server.rs
+++ b/monoio-http/examples/echo_server.rs
@@ -8,7 +8,7 @@ use monoio::{
     net::{TcpListener, TcpStream},
 };
 use monoio_http::{
-    common::{request::Request, response::Response},
+    common::{error::HttpError, request::Request, response::Response},
     h1::{
         codec::{
             decoder::RequestDecoder,
@@ -69,8 +69,8 @@ async fn handle_connection(stream: TcpStream) {
 
 async fn handle_task(
     mut receiver: SPSCReceiver<Request>,
-    mut sender: impl Sink<Response, Error = impl Into<EncodeError>>,
-) -> Result<(), EncodeError> {
+    mut sender: impl Sink<Response, Error = impl Into<HttpError>>,
+) -> Result<(), HttpError> {
     loop {
         let request = match receiver.recv().await {
             Some(r) => r,

--- a/monoio-http/examples/echo_server.rs
+++ b/monoio-http/examples/echo_server.rs
@@ -10,10 +10,7 @@ use monoio::{
 use monoio_http::{
     common::{error::HttpError, request::Request, response::Response},
     h1::{
-        codec::{
-            decoder::RequestDecoder,
-            encoder::{EncodeError, GenericEncoder},
-        },
+        codec::{decoder::RequestDecoder, encoder::GenericEncoder},
         payload::{FixedPayload, Payload},
     },
     util::spsc::{spsc_pair, SPSCReceiver},

--- a/monoio-http/examples/h2_monoio_server.rs
+++ b/monoio-http/examples/h2_monoio_server.rs
@@ -10,7 +10,7 @@ use monoio_http::h2::{
 
 #[monoio::main]
 async fn main() {
-    let listener = TcpListener::bind("127.0.0.1:59288").unwrap();
+    let listener = TcpListener::bind("127.0.0.1:8081").unwrap();
     println!("listening on {:?}", listener.local_addr());
 
     loop {

--- a/monoio-http/src/common/error.rs
+++ b/monoio-http/src/common/error.rs
@@ -1,0 +1,20 @@
+use thiserror::Error as ThisError;
+
+use crate::h1::{
+    codec::{decoder::DecodeError, encoder::EncodeError},
+    payload::PayloadError,
+};
+
+#[derive(ThisError, Debug)]
+pub enum HttpError {
+    #[error("http1 Encode error {0}")]
+    H1EncodeError(#[from] EncodeError),
+    #[error("http2 decode error {0}")]
+    H1DecodeError(#[from] DecodeError),
+    #[error("receive body error {0}")]
+    PayloadError(#[from] PayloadError),
+    #[error("H2 error {0}")]
+    H2Error(#[from] crate::h2::Error),
+    #[error("IO error {0}")]
+    IOError(#[from] std::io::Error),
+}

--- a/monoio-http/src/common/mod.rs
+++ b/monoio-http/src/common/mod.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 
 pub mod body;
+pub mod error;
 pub mod ext;
 pub mod request;
 pub mod response;

--- a/monoio-http/src/h1/codec/encoder.rs
+++ b/monoio-http/src/h1/codec/encoder.rs
@@ -12,6 +12,7 @@ use thiserror::Error as ThisError;
 use crate::{
     common::{
         body::{Body, StreamHint},
+        error::HttpError,
         ext::Reason,
         request::RequestHead,
         response::ResponseHead,
@@ -235,9 +236,9 @@ where
     R::Body: Body,
     HeadEncoder: Encoder<R::Parts>,
     <HeadEncoder as Encoder<R::Parts>>::Error: Into<EncodeError>,
-    EncodeError: From<<<R as IntoParts>::Body as Body>::Error>,
+    HttpError: From<<<R as IntoParts>::Body as Body>::Error>,
 {
-    type Error = EncodeError;
+    type Error = HttpError;
 
     type SendFuture<'a> = impl Future<Output = Result<(), Self::Error>> + 'a where Self: 'a, R: 'a;
 

--- a/monoio-http/src/h2/codec/framed_write.rs
+++ b/monoio-http/src/h2/codec/framed_write.rs
@@ -163,7 +163,7 @@ where
                             total_bytes
                         );
 
-                        #[allow(cast_ref_to_mut)]
+                        #[allow(clippy::cast_ref_to_mut)]
                         let io = unsafe { &mut *(&self.inner as *const T as *mut T) };
                         let write_fut = async move {
                             let res1 = io.write_all(encoder_buf_bytes).await;
@@ -194,7 +194,7 @@ where
                             encoder_buf_bytes.remaining()
                         );
 
-                        #[allow(cast_ref_to_mut)]
+                        #[allow(clippy::cast_ref_to_mut)]
                         let io = unsafe { &mut *(&self.inner as *const T as *mut T) };
                         self.write_fut.arm_future(io.write_all(encoder_buf_bytes));
 
@@ -212,7 +212,7 @@ where
 
         tracing::trace!("flushing buffer io");
         if !self.flush_fut.armed() {
-            #[allow(cast_ref_to_mut)]
+            #[allow(clippy::cast_ref_to_mut)]
             let io = unsafe { &mut *(&self.inner as *const T as *mut T) };
             tracing::trace!("Framed write Flush returning");
             self.flush_fut.arm_future(io.flush());
@@ -228,7 +228,7 @@ where
         ready!(self.flush(cx))?;
 
         if !self.shut_fut.armed() {
-            #[allow(cast_ref_to_mut)]
+            #[allow(clippy::cast_ref_to_mut)]
             let io = unsafe { &mut *(&self.inner as *const T as *mut T) };
             self.flush_fut.arm_future(io.shutdown());
         }

--- a/monoio-http/src/h2/codec/mod.rs
+++ b/monoio-http/src/h2/codec/mod.rs
@@ -167,8 +167,8 @@ where
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         if !self.stream_fut.armed() {
-            #[allow(cast_ref_to_mut)]
             let stream = unsafe {
+                #[allow(clippy::cast_ref_to_mut)]
                 &mut *(&self.inner as *const FramedRead<FramedWrite<T, B>>
                     as *mut FramedRead<FramedWrite<T, B>>)
             };
@@ -178,34 +178,6 @@ where
         Poll::Ready(ready!(self.stream_fut.poll(cx)))
     }
 }
-
-// Sink trait is not being used as of now in H2 crate. Frames are wriiten via codec's own APIs
-// impl<T, B> Sink<Frame<B>> for Codec<T, B>
-// where
-//     T: AsyncWriteRent + Unpin,
-//     B: Buf,
-// {
-//     type Error = SendError;
-
-//     fn start_send(mut self: Pin<&mut Self>, item: Frame<B>) -> Result<(), Self::Error> {
-//         Codec::buffer(&mut self, item)?;
-//         Ok(())
-//     }
-//     /// Returns `Ready` when the codec can buffer a frame
-//     fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(),
-// Self::Error>> {         self.framed_write().poll_ready(cx).map_err(Into::into)
-//     }
-
-//     /// Flush buffered data to the wire
-//     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(),
-// Self::Error>> {         self.framed_write().flush(cx).map_err(Into::into)
-//     }
-
-//     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(),
-// Self::Error>> {         ready!(self.shutdown(cx))?;
-//         Poll::Ready(Ok(()))
-//     }
-// }
 
 // TODO: remove (or improve) this
 impl<T> From<T> for Codec<T, bytes::Bytes>

--- a/monoio-http/src/h2/server.rs
+++ b/monoio-http/src/h2/server.rs
@@ -1234,7 +1234,8 @@ where
 
         if !self.read_fut.armed() {
             let io = self.inner_mut();
-            #[allow(cast_ref_to_mut)]
+
+            #[allow(clippy::cast_ref_to_mut)]
             let io = unsafe { &mut *(io as *const T as *mut T) };
             self.read_fut.arm_future(io.read_exact(owned_buf));
         }


### PR DESCRIPTION
- Introduce http2 support for the client
- Refactored client code to a pipe and connection manager model, should be easier to add H3 support in future
- Introduce new Body trait and common body for H1 and H2
- Examples - `h1_client`,  `h2_client` and `auto_client`

TODO:
- [ ] Trailer support
- [ ] ALPN