### PR TITLE
Build fixes for Rust nightly 1.72

### DIFF
--- a/monoio-http-client/src/client/connection.rs
+++ b/monoio-http-client/src/client/connection.rs
@@ -156,7 +156,7 @@ impl<IO: AsyncReadRent + AsyncWriteRent + Split> HttpConnection<IO> {
                             let _ = data_tx.send(Some(r));
                         }
                         *handle = Some(framed_payload.get_source());
-                        
+
                         let resp = Response::from_parts(parts, framed_payload_rcvr.into());
                         (Ok(resp), false)
                     }

--- a/monoio-http-client/src/client/connector.rs
+++ b/monoio-http-client/src/client/connector.rs
@@ -7,18 +7,15 @@ use std::{
     net::ToSocketAddrs,
 };
 
-use bytes::Bytes;
 use http::Version;
 use monoio::{
     io::{AsyncReadRent, AsyncWriteRent, Split},
     net::TcpStream,
 };
-use monoio_http::{
-    h1::codec::ClientCodec,
-};
+use monoio_http::h1::codec::ClientCodec;
 
 use super::{
-    connection::{HttpConnection},
+    connection::HttpConnection,
     key::HttpVersion,
     pool::{ConnectionPool, PooledConnection},
     ClientGlobalConfig, ConnectionConfig, Proto,
@@ -150,11 +147,7 @@ impl HttpConnector {
         Self { conn_config }
     }
 
-    pub async fn connect<IO>(
-        &self,
-        io: IO,
-        version: Version,
-    ) -> crate::Result<HttpConnection<IO>>
+    pub async fn connect<IO>(&self, io: IO, version: Version) -> crate::Result<HttpConnection<IO>>
     where
         IO: AsyncReadRent + AsyncWriteRent + Split + Unpin + 'static,
     {
@@ -169,9 +162,7 @@ impl HttpConnector {
         };
 
         match proto {
-            Version::HTTP_11 => {
-                Ok(HttpConnection::H1(Some(ClientCodec::new(io))))
-            }
+            Version::HTTP_11 => Ok(HttpConnection::H1(Some(ClientCodec::new(io)))),
             Version::HTTP_2 => {
                 let (send_request, h2_conn) = self.conn_config.h2_builder.handshake(io).await?;
                 monoio::spawn(async move {
@@ -179,7 +170,7 @@ impl HttpConnector {
                         println!("H2 CONN ERR={:?}", e);
                     }
                 });
-               Ok(HttpConnection::H2(send_request))
+                Ok(HttpConnection::H2(send_request))
             }
             _ => {
                 unreachable!()
@@ -194,7 +185,7 @@ impl HttpConnector {
 pub struct PooledConnector<TC, K, IO>
 where
     K: Hash + Eq + Display,
-    IO: AsyncWriteRent+ AsyncReadRent + Split
+    IO: AsyncWriteRent + AsyncReadRent + Split,
 {
     global_config: ClientGlobalConfig,
     transport_connector: TC,
@@ -224,7 +215,7 @@ impl<TC, K, IO> PooledConnector<TC, K, IO>
 where
     TC: Default,
     K: Hash + Eq + Display + 'static,
-    IO: AsyncReadRent + AsyncWriteRent + Split +'static,
+    IO: AsyncReadRent + AsyncWriteRent + Split + 'static,
 {
     pub fn new(global_config: ClientGlobalConfig, c_config: ConnectionConfig) -> Self {
         Self {

--- a/monoio-http-client/src/client/pool.rs
+++ b/monoio-http-client/src/client/pool.rs
@@ -21,11 +21,11 @@ use monoio::io::{AsyncReadRent, AsyncWriteRent, Split};
 use monoio_http::common::{
     body::{Body, HttpBody},
     error::HttpError,
-    request::Request, response::Response,
+    request::Request,
+    response::Response,
 };
 
 use super::connection::HttpConnection;
-
 
 const CONN_CLOSE: &[u8] = b"close";
 
@@ -162,7 +162,6 @@ where
     remove_h2: bool, // Remove H2 Connection
 }
 
-
 impl<K, IO> PooledConnection<K, IO>
 where
     K: Hash + Eq + Display,
@@ -184,8 +183,8 @@ where
                             self.set_reusable(!v.as_bytes().eq_ignore_ascii_case(CONN_CLOSE))
                         }
                         Ok(resp)
-                    },
-                    Err(e) => Err(e)
+                    }
+                    Err(e) => Err(e),
                 }
             }
             None => Err(crate::Error::MissingCodec),

--- a/monoio-http/examples/h2_monoio_client.rs
+++ b/monoio-http/examples/h2_monoio_client.rs
@@ -4,7 +4,7 @@ use monoio_http::h2::client;
 
 #[monoio::main]
 async fn main() {
-    let tcp = TcpStream::connect("127.0.0.1:59288").await.unwrap();
+    let tcp = TcpStream::connect("127.0.0.1:7081").await.unwrap();
     let (mut client, h2) = client::handshake(tcp).await.unwrap();
 
     // Spawn a task to run the conn...

--- a/monoio-http/examples/h2_monoio_server.rs
+++ b/monoio-http/examples/h2_monoio_server.rs
@@ -10,7 +10,7 @@ use monoio_http::h2::{
 
 #[monoio::main]
 async fn main() {
-    let listener = TcpListener::bind("127.0.0.1:8081").unwrap();
+    let listener = TcpListener::bind("127.0.0.1:7081").unwrap();
     println!("listening on {:?}", listener.local_addr());
 
     loop {

--- a/monoio-http/src/h2/codec/framed_read.rs
+++ b/monoio-http/src/h2/codec/framed_read.rs
@@ -57,10 +57,6 @@ impl<T> FramedRead<T> {
         }
     }
 
-    pub fn get_ref(&self) -> &T {
-        self.inner.get_ref()
-    }
-
     pub fn get_mut(&mut self) -> &mut T {
         self.inner.get_mut()
     }
@@ -365,11 +361,6 @@ where
                     }
                     Err(e) => return Some(Err(e)),
                 }
-
-                // if let Some(frame) = decode_frame(hpack, max_header_list_size, partial, bytes)? {
-                //     tracing::debug!(?frame, "received");
-                //     return Some(Ok(frame));
-                // }
             }
         }
     }


### PR DESCRIPTION
- Replaced casts which are no longer supported with UnsafeCell