### PR TITLE
feat: allow custom connector and refactor related code

### DIFF
--- a/monoio-http-client/Cargo.toml
+++ b/monoio-http-client/Cargo.toml
@@ -11,10 +11,9 @@ name = "monoio-http-client"
 version = "0.2.2"
 
 [dependencies]
-
 monoio = { version = "0.1.5" }
 monoio-http = { version = "0.2.0", path = "../monoio-http" }
-monoio-rustls = { version = "0.1.2", optional = true }
+monoio-rustls = { version = "0.1.2" }
 monoio-native-tls = { version = "0.1.0", optional = true }
 service-async = { version = "0.1.2" }
 
@@ -25,27 +24,25 @@ serde = "1"
 serde_json = "1"
 smol_str = "0.2"
 thiserror = "1"
-rustls = { version = "0", default-features = false, optional = true, features = [
+rustls = { version = "0", default-features = false, features = [
     "dangerous_configuration",
 ] }
 tracing = { version = "0.1", optional = true }
-webpki-roots = { version = "0.23", optional = true }
+webpki-roots = "0.23"
 native-tls = { version = "0.2", optional = true }
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
-tracing = { version = "0.1" }
-tracing-subscriber = { version = "0.3" }
+tracing = "0.1"
+tracing-subscriber = "0.3"
 
 [features]
-default = ["rustls", "time"]
+default = ["time"]
 # Enable this feature to make connection pool periodically checking works.
 # You must enable time driver to use it.
 time = []
 
 # Note: rustls and native-tls cannot be enabled at the same time
-rustls = ["dep:rustls", "webpki-roots", "monoio-rustls"]
-rustls-unsafe-io = ["rustls", "monoio-rustls?/unsafe_io"]
+rustls-unsafe-io = ["monoio-rustls/unsafe_io"]
 native-tls = ["dep:native-tls", "monoio-native-tls"]
-
-logging = ["tracing", "monoio-rustls?/logging"]
+logging = ["tracing", "monoio-rustls/logging"]

--- a/monoio-http-client/examples/auto_client.rs
+++ b/monoio-http-client/examples/auto_client.rs
@@ -15,7 +15,7 @@ async fn main() {
     // Looks at the version header to determine the type of connection.
     // Will default to HTTP1_1
 
-    let h1_client = monoio_http_client::Builder::new().build_auto();
+    let h1_client = monoio_http_client::Builder::new().http_auto().build();
     let client1 = h1_client.clone();
     let client2 = h1_client.clone();
 
@@ -53,7 +53,7 @@ async fn main() {
 
         let request = Builder::new()
             .method(Method::GET)
-            .uri("http://127.0.0.1:8080/")
+            .uri("https://httpbin.org/html")
             .version(Version::HTTP_2)
             .body(body)
             .unwrap();

--- a/monoio-http-client/examples/custom_connector.rs
+++ b/monoio-http-client/examples/custom_connector.rs
@@ -1,0 +1,85 @@
+#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
+
+use std::future::Future;
+
+use monoio_http_client::{
+    unified::{UnifiedTransportAddr, UnifiedTransportConnection, UnifiedTransportConnector},
+    Client, Connector, Error, Key,
+};
+use service_async::Param;
+
+#[monoio::main(enable_timer = true)]
+async fn main() {
+    let client = Client::builder().build_with_connector(CloudflareConnector::default());
+    let resp = client
+        .get("https://ihc.im")
+        .send()
+        .await
+        .expect("request fail");
+    let http_resp = resp.bytes().await.unwrap();
+    // Output is expected to be "error code: 1034"
+    println!("{:?}", http_resp);
+
+    // Run `socat UNIX-LISTEN:/tmp/proxy.sock TCP:1.1.1.1:443`
+    let client = Client::builder().build_with_connector(CustomUnixConnector::default());
+    let resp = client
+        .get("https://ihc.im")
+        .send()
+        .await
+        .expect("request fail");
+    let http_resp = resp.bytes().await.unwrap();
+    // Output is expected to be "error code: 1034"
+    println!("{:?}", http_resp);
+}
+
+/// Force resolve to 1.1.1.1:443
+#[derive(Default)]
+struct CloudflareConnector {
+    inner: UnifiedTransportConnector,
+}
+
+impl Connector<Key> for CloudflareConnector {
+    type Connection = UnifiedTransportConnection;
+    type Error = Error;
+
+    type ConnectionFuture<'a> = impl Future<Output = Result<Self::Connection, Self::Error>> + 'a;
+
+    fn connect(&self, mut key: Key) -> Self::ConnectionFuture<'_> {
+        async move {
+            key.host = "1.1.1.1".into();
+            key.port = 443;
+
+            self.inner.connect(key).await
+        }
+    }
+}
+
+/// Force resolve to unix /tmp/proxy.sock
+#[derive(Default)]
+struct CustomUnixConnector {
+    inner: UnifiedTransportConnector,
+}
+
+impl Connector<Key> for CustomUnixConnector {
+    type Connection = UnifiedTransportConnection;
+    type Error = Error;
+
+    type ConnectionFuture<'a> = impl Future<Output = Result<Self::Connection, Self::Error>> + 'a;
+
+    fn connect(&self, key: Key) -> Self::ConnectionFuture<'_> {
+        async move {
+            let modified = "/tmp/proxy.sock".into();
+            let addr = match key.param() {
+                UnifiedTransportAddr::Tcp(_, _) => UnifiedTransportAddr::Unix(modified),
+                UnifiedTransportAddr::Unix(_) => UnifiedTransportAddr::Unix(modified),
+                UnifiedTransportAddr::TcpTls(_, _, sn) => {
+                    UnifiedTransportAddr::UnixTls(modified, sn)
+                }
+                UnifiedTransportAddr::UnixTls(_, sn) => UnifiedTransportAddr::UnixTls(modified, sn),
+            };
+
+            self.inner.connect(addr).await
+        }
+    }
+}

--- a/monoio-http-client/examples/h1_client.rs
+++ b/monoio-http-client/examples/h1_client.rs
@@ -11,7 +11,7 @@ async fn main() {
     tracing::subscriber::set_global_default(subscriber)
         .expect("Failed to set up the tracing subscriber");
 
-    let h1_client = monoio_http_client::Builder::new().build_http1();
+    let h1_client = monoio_http_client::Builder::new().http1_client().build();
     let client1 = h1_client.clone();
     let client2 = h1_client.clone();
 

--- a/monoio-http-client/examples/h2_client.rs
+++ b/monoio-http-client/examples/h2_client.rs
@@ -14,7 +14,7 @@ async fn main() {
     tracing::subscriber::set_global_default(subscriber)
         .expect("Failed to set up the tracing subscriber");
 
-    let h2_client = monoio_http_client::Builder::new().build_http2();
+    let h2_client = monoio_http_client::Builder::new().http2_client().build();
     let mut first = true;
 
     for _ in 0..6 {

--- a/monoio-http-client/src/client/connection.rs
+++ b/monoio-http-client/src/client/connection.rs
@@ -16,8 +16,6 @@ use monoio_http::{
     h2::{client::SendRequest, SendStream},
 };
 
-use crate::Error;
-
 pub struct StreamBodyTask<B: Body> {
     stream_pipe: SendStream<Bytes>,
     body: B,
@@ -116,7 +114,7 @@ impl<B: Body<Data = Bytes>> StreamBodyTask<B> {
     }
 }
 
-pub enum HttpConnection<IO: AsyncReadRent + AsyncWriteRent + Split> {
+pub enum HttpConnection<IO: AsyncWriteRent> {
     H1(Option<ClientCodec<IO>>),
     H2(SendRequest<Bytes>),
 }
@@ -133,7 +131,7 @@ impl<IO: AsyncReadRent + AsyncWriteRent + Split> HttpConnection<IO> {
             Self::H1(ref mut handle) => {
                 let mut h = match handle.take() {
                     Some(h) => h,
-                    None => return (Err(Error::MissingCodec), false),
+                    None => return (Err(crate::Error::MissingCodec), false),
                 };
 
                 if let Err(e) = h.send_and_flush(request).await {

--- a/monoio-http-client/src/client/unified.rs
+++ b/monoio-http-client/src/client/unified.rs
@@ -1,0 +1,221 @@
+use std::{
+    future::Future,
+    io,
+    net::ToSocketAddrs,
+    path::{Path, PathBuf},
+};
+
+use monoio::{
+    buf::{IoBuf, IoBufMut, IoVecBuf, IoVecBufMut},
+    io::{AsyncReadRent, AsyncWriteRent, Split},
+    net::{TcpStream, UnixStream},
+    BufResult,
+};
+use service_async::Param;
+use smol_str::SmolStr;
+
+use super::connector::{TcpConnector, TlsConnector, TlsStream, UnixConnector};
+use crate::Connector;
+
+// TODO: make its PathBuf and SmolStr to ref
+#[derive(Clone)]
+pub enum UnifiedTransportAddr {
+    Tcp(SmolStr, u16),
+    Unix(PathBuf),
+    TcpTls(SmolStr, u16, super::key::ServerName),
+    UnixTls(PathBuf, super::key::ServerName),
+}
+
+struct TcpTlsAddr<'a>(&'a SmolStr, u16, &'a super::key::ServerName);
+struct UnixTlsAddr<'a>(&'a PathBuf, &'a super::key::ServerName);
+impl<'a> ToSocketAddrs for TcpTlsAddr<'a> {
+    type Iter = <(&'static str, u16) as ToSocketAddrs>::Iter;
+    fn to_socket_addrs(&self) -> io::Result<Self::Iter> {
+        (self.0.as_str(), self.1).to_socket_addrs()
+    }
+}
+impl<'a> service_async::Param<super::key::ServerName> for TcpTlsAddr<'a> {
+    fn param(&self) -> super::key::ServerName {
+        self.2.clone()
+    }
+}
+impl<'a> AsRef<Path> for UnixTlsAddr<'a> {
+    fn as_ref(&self) -> &Path {
+        self.0
+    }
+}
+impl<'a> service_async::Param<super::key::ServerName> for UnixTlsAddr<'a> {
+    fn param(&self) -> super::key::ServerName {
+        self.1.clone()
+    }
+}
+
+#[derive(Default, Clone, Debug)]
+pub struct UnifiedTransportConnector {
+    raw_tcp: TcpConnector,
+    raw_unix: UnixConnector,
+    tcp_tls: TlsConnector<TcpConnector>,
+    unix_tls: TlsConnector<UnixConnector>,
+}
+
+pub enum UnifiedTransportConnection {
+    Tcp(TcpStream),
+    Unix(UnixStream),
+    TcpTls(TlsStream<TcpStream>),
+    UnixTls(TlsStream<UnixStream>),
+    // TODO
+    // Custom(Box<dyn ...>)
+}
+
+impl std::fmt::Debug for UnifiedTransportConnection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Tcp(_) => write!(f, "Tcp"),
+            Self::Unix(_) => write!(f, "Unix"),
+            Self::TcpTls(_) => write!(f, "TcpTls"),
+            Self::UnixTls(_) => write!(f, "UnixTls"),
+        }
+    }
+}
+
+impl<T> Connector<T> for UnifiedTransportConnector
+where
+    T: Param<UnifiedTransportAddr>,
+{
+    type Connection = UnifiedTransportConnection;
+    type Error = crate::Error;
+
+    type ConnectionFuture<'a> = impl Future<Output = Result<Self::Connection, Self::Error>> + 'a where T: 'a;
+
+    fn connect(&self, key: T) -> Self::ConnectionFuture<'_> {
+        async move {
+            let unified_addr = key.param();
+            match &unified_addr {
+                UnifiedTransportAddr::Tcp(addr, port) => self
+                    .raw_tcp
+                    .connect((addr.as_str(), *port))
+                    .await
+                    .map_err(Into::into)
+                    .map(UnifiedTransportConnection::Tcp),
+                UnifiedTransportAddr::Unix(path) => self
+                    .raw_unix
+                    .connect(path)
+                    .await
+                    .map_err(Into::into)
+                    .map(UnifiedTransportConnection::Unix),
+                UnifiedTransportAddr::TcpTls(addr, port, tls) => self
+                    .tcp_tls
+                    .connect(TcpTlsAddr(addr, *port, tls))
+                    .await
+                    .map_err(Into::into)
+                    .map(UnifiedTransportConnection::TcpTls),
+                UnifiedTransportAddr::UnixTls(path, tls) => self
+                    .unix_tls
+                    .connect(UnixTlsAddr(path, tls))
+                    .await
+                    .map_err(Into::into)
+                    .map(UnifiedTransportConnection::UnixTls),
+            }
+        }
+    }
+}
+
+impl AsyncReadRent for UnifiedTransportConnection {
+    type ReadFuture<'a, T> = impl Future<Output = BufResult<usize, T>> + 'a
+    where
+        Self: 'a,
+        T: IoBufMut + 'a;
+
+    type ReadvFuture<'a, T> = impl Future<Output = BufResult<usize, T>> + 'a
+    where
+        Self: 'a,
+        T: IoVecBufMut + 'a;
+
+    fn read<T: IoBufMut>(&mut self, buf: T) -> Self::ReadFuture<'_, T> {
+        async move {
+            match self {
+                UnifiedTransportConnection::Tcp(s) => s.read(buf).await,
+                UnifiedTransportConnection::Unix(s) => s.read(buf).await,
+                UnifiedTransportConnection::TcpTls(s) => s.read(buf).await,
+                UnifiedTransportConnection::UnixTls(s) => s.read(buf).await,
+            }
+        }
+    }
+
+    fn readv<T: IoVecBufMut>(&mut self, buf: T) -> Self::ReadvFuture<'_, T> {
+        async move {
+            match self {
+                UnifiedTransportConnection::Tcp(s) => s.readv(buf).await,
+                UnifiedTransportConnection::Unix(s) => s.readv(buf).await,
+                UnifiedTransportConnection::TcpTls(s) => s.readv(buf).await,
+                UnifiedTransportConnection::UnixTls(s) => s.readv(buf).await,
+            }
+        }
+    }
+}
+
+impl AsyncWriteRent for UnifiedTransportConnection {
+    type WriteFuture<'a, T> = impl Future<Output = BufResult<usize, T>> + 'a
+    where
+        Self: 'a,
+        T: IoBuf + 'a;
+
+    type WritevFuture<'a, T> = impl Future<Output = BufResult<usize, T>> + 'a
+    where
+        Self: 'a,
+        T: IoVecBuf + 'a;
+
+    type FlushFuture<'a> = impl Future<Output = io::Result<()>> + 'a
+    where
+        Self: 'a;
+
+    type ShutdownFuture<'a> = impl Future<Output = io::Result<()>> + 'a
+    where
+        Self: 'a;
+
+    fn write<T: IoBuf>(&mut self, buf: T) -> Self::WriteFuture<'_, T> {
+        async move {
+            match self {
+                UnifiedTransportConnection::Tcp(s) => s.write(buf).await,
+                UnifiedTransportConnection::Unix(s) => s.write(buf).await,
+                UnifiedTransportConnection::TcpTls(s) => s.write(buf).await,
+                UnifiedTransportConnection::UnixTls(s) => s.write(buf).await,
+            }
+        }
+    }
+
+    fn writev<T: IoVecBuf>(&mut self, buf: T) -> Self::WritevFuture<'_, T> {
+        async move {
+            match self {
+                UnifiedTransportConnection::Tcp(s) => s.writev(buf).await,
+                UnifiedTransportConnection::Unix(s) => s.writev(buf).await,
+                UnifiedTransportConnection::TcpTls(s) => s.writev(buf).await,
+                UnifiedTransportConnection::UnixTls(s) => s.writev(buf).await,
+            }
+        }
+    }
+
+    fn flush(&mut self) -> Self::FlushFuture<'_> {
+        async move {
+            match self {
+                UnifiedTransportConnection::Tcp(s) => s.flush().await,
+                UnifiedTransportConnection::Unix(s) => s.flush().await,
+                UnifiedTransportConnection::TcpTls(s) => s.flush().await,
+                UnifiedTransportConnection::UnixTls(s) => s.flush().await,
+            }
+        }
+    }
+
+    fn shutdown(&mut self) -> Self::ShutdownFuture<'_> {
+        async move {
+            match self {
+                UnifiedTransportConnection::Tcp(s) => s.shutdown().await,
+                UnifiedTransportConnection::Unix(s) => s.shutdown().await,
+                UnifiedTransportConnection::TcpTls(s) => s.shutdown().await,
+                UnifiedTransportConnection::UnixTls(s) => s.shutdown().await,
+            }
+        }
+    }
+}
+
+unsafe impl Split for UnifiedTransportConnection {}

--- a/monoio-http-client/src/error.rs
+++ b/monoio-http-client/src/error.rs
@@ -10,7 +10,7 @@ pub enum Error {
     H1Decode(#[from] monoio_http::h1::codec::decoder::DecodeError),
     #[error("io error {0}")]
     Io(#[from] std::io::Error),
-    #[cfg(feature = "rustls")]
+    #[cfg(not(feature = "native-tls"))]
     #[error("rustls error {0}")]
     Rustls(#[from] monoio_rustls::TlsError),
     #[cfg(feature = "native-tls")]

--- a/monoio-http-client/src/lib.rs
+++ b/monoio-http-client/src/lib.rs
@@ -6,7 +6,7 @@ mod error;
 mod request;
 mod response;
 
-pub use client::{connector::Connector, Builder, Client, ClientConfig};
+pub use client::{connector::Connector, key::Key, unified, Builder, Client, ClientConfig};
 pub use error::{Error, Result};
 pub use request::ClientRequest;
 pub use response::ClientResponse;

--- a/monoio-http/src/h2/client.rs
+++ b/monoio-http/src/h2/client.rs
@@ -1376,7 +1376,7 @@ impl PushPromises {
     #[doc(hidden)]
     pub fn poll_push_promise(
         &mut self,
-        cx: &mut Context<'_>,
+        cx: &Context<'_>,
     ) -> Poll<Option<Result<PushPromise, crate::h2::Error>>> {
         match self.inner.poll_pushed(cx) {
             Poll::Ready(Some(Ok((request, response)))) => {

--- a/monoio-http/src/h2/hpack/decoder.rs
+++ b/monoio-http/src/h2/hpack/decoder.rs
@@ -446,7 +446,7 @@ fn decode_int<B: Buf>(buf: &mut B, prefix_size: u8) -> Result<usize, DecoderErro
     Err(DecoderError::NeedMore(NeedMore::IntegerUnderflow))
 }
 
-fn peek_u8<B: Buf>(buf: &mut B) -> Option<u8> {
+fn peek_u8<B: Buf>(buf: &B) -> Option<u8> {
     if buf.has_remaining() {
         Some(buf.chunk()[0])
     } else {
@@ -834,9 +834,9 @@ mod test {
     fn test_peek_u8() {
         let b = 0xff;
         let mut buf = Cursor::new(vec![b]);
-        assert_eq!(peek_u8(&mut buf), Some(b));
+        assert_eq!(peek_u8(&buf), Some(b));
         assert_eq!(buf.get_u8(), b);
-        assert_eq!(peek_u8(&mut buf), None);
+        assert_eq!(peek_u8(&buf), None);
     }
 
     #[test]

--- a/monoio-http/src/h2/proto/streams/recv.rs
+++ b/monoio-http/src/h2/proto/streams/recv.rs
@@ -132,7 +132,7 @@ impl Recv {
         &mut self,
         id: StreamId,
         mode: Open,
-        counts: &mut Counts,
+        counts: &Counts,
     ) -> Result<Option<StreamId>, Error> {
         assert!(self.refused.is_none());
 

--- a/monoio-http/src/h2/proto/streams/streams.rs
+++ b/monoio-http/src/h2/proto/streams/streams.rs
@@ -416,11 +416,7 @@ impl Inner {
                     }
                 }
 
-                match self
-                    .actions
-                    .recv
-                    .open(id, Open::Headers, &mut self.counts)?
-                {
+                match self.actions.recv.open(id, Open::Headers, &self.counts)? {
                     Some(stream_id) => {
                         let stream = Stream::new(
                             stream_id,
@@ -731,7 +727,7 @@ impl Inner {
         if self
             .actions
             .recv
-            .open(promised_id, Open::PushPromise, &mut self.counts)?
+            .open(promised_id, Open::PushPromise, &self.counts)?
             .is_none()
         {
             return Ok(());

--- a/monoio-http/src/h2/share.rs
+++ b/monoio-http/src/h2/share.rs
@@ -428,10 +428,7 @@ impl RecvStream {
     }
 
     /// Poll for the next data frame.
-    pub fn poll_data(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Bytes, crate::h2::Error>>> {
+    pub fn poll_data(&mut self, cx: &Context<'_>) -> Poll<Option<Result<Bytes, crate::h2::Error>>> {
         self.inner.inner.poll_data(cx).map_err(Into::into)
     }
 

--- a/monoio-http/src/util/spsc.rs
+++ b/monoio-http/src/util/spsc.rs
@@ -63,7 +63,7 @@ impl<T> Default for Shared<T> {
 
 impl<T> SPSCReceiver<T> {
     /// None: closed; Some: item
-    pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
+    pub fn poll_recv(&mut self, cx: &Context<'_>) -> Poll<Option<T>> {
         let inner = unsafe { &mut *self.inner.get() };
         // If we can get something from slot:
         //  1. take it and clear receiver_waker
@@ -118,7 +118,7 @@ impl<'a, T> Future for Recv<'a, T> {
 
 impl<T> SPSCSender<T> {
     /// None: closed; Some: the slot is empty
-    pub fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Option<()>> {
+    pub fn poll_ready(&mut self, cx: &Context<'_>) -> Poll<Option<()>> {
         let inner = unsafe { &mut *self.inner.get() };
         // If closed:
         //  1. return None
@@ -136,7 +136,7 @@ impl<T> SPSCSender<T> {
         Poll::Ready(Some(()))
     }
 
-    pub fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+    pub fn poll_closed(&mut self, cx: &Context<'_>) -> Poll<()> {
         let inner = unsafe { &mut *self.inner.get() };
         // If closed:
         //  1. return

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2023-06-29


### PR DESCRIPTION
1. Add unified connector, connection and address repr.
2. Allow user set custom connector to make unix socket work.
3. Remove dual tls feature and conditional generic type when tls enabled.
4. Remove useless bound requirements.