### PR TITLE
Add a decode_content and encode_content method

### DIFF
--- a/monoio-http-client/src/response.rs
+++ b/monoio-http-client/src/response.rs
@@ -63,7 +63,7 @@ impl ClientResponse {
 
     /// Get the full response body as `Bytes`.
     pub async fn bytes(self) -> crate::Result<Bytes> {
-        let mut body = self.body;
+        let body = self.body;
         body.bytes().await.map_err(Into::into)
     }
 
@@ -76,7 +76,7 @@ impl ClientResponse {
     // Note: using from_reader to read discontinuous data pays more
     // than using from_slice. So here we read the entire content into
     // a Bytes and call from_slice.
-    pub async fn json<T: serde::de::DeserializeOwned>(mut self) -> crate::Result<T> {
+    pub async fn json<T: serde::de::DeserializeOwned>(self) -> crate::Result<T> {
         let bytes = self.body.bytes().await?;
         let d = serde_json::from_slice(&bytes)?;
         Ok(d)

--- a/monoio-http/Cargo.toml
+++ b/monoio-http/Cargo.toml
@@ -24,6 +24,8 @@ memchr = "2.5"
 thiserror = "1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 local-sync = "0.1"
+flate2 = "1"
+brotli = "3.3"
 
 # H2 crate dependencies
 futures-core = { version = "0.3", default-features = false }

--- a/monoio-http/src/common/body.rs
+++ b/monoio-http/src/common/body.rs
@@ -17,6 +17,8 @@ use crate::{
     h2::RecvStream,
 };
 
+const supported_encodings: [&str; 3] = ["gzip", "br", "deflate"];
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StreamHint {
     None,
@@ -142,7 +144,7 @@ where
                 .split(',')
                 .map(|s| s.trim().to_string())
                 .collect();
-            let supported_encodings = vec!["gzip", "br", "deflate"];
+
             // Find the first supported encoding from the accepted encodings
             let selected_encoding = accepted_encodings
                 .iter()


### PR DESCRIPTION
- Introduce decode_content and encode_content as part of BodyExt trait
- Required for gzip support on monolake 