### PR TITLE
timeout: add timeout to http decoder

### DIFF
--- a/monoio-http-client/src/client/connector.rs
+++ b/monoio-http-client/src/client/connector.rs
@@ -180,7 +180,7 @@ impl HttpConnector {
         };
 
         match proto {
-            Version::HTTP_11 => Ok(HttpConnection::H1(ClientCodec::new(io))),
+            Version::HTTP_11 => Ok(HttpConnection::H1(ClientCodec::new(io, None))),
             Version::HTTP_2 => {
                 let (send_request, h2_conn) = self.conn_config.h2_builder.handshake(io).await?;
                 monoio::spawn(async move {

--- a/monoio-http/examples/echo_server.rs
+++ b/monoio-http/examples/echo_server.rs
@@ -37,7 +37,7 @@ async fn main() {
 async fn handle_connection(stream: TcpStream) {
     let (r, w) = stream.into_split();
     let sender = GenericEncoder::new(w);
-    let mut receiver = RequestDecoder::new(r);
+    let mut receiver = RequestDecoder::new(r, None);
     let (mut tx, rx) = spsc_pair();
     monoio::spawn(handle_task(rx, sender));
 

--- a/monoio-http/examples/get_client.rs
+++ b/monoio-http/examples/get_client.rs
@@ -29,7 +29,7 @@ async fn main() {
         .await
         .expect("unable to connect");
     // You can also use raw io with encoder and decoder manually.
-    let mut codec = ClientCodec::new(conn);
+    let mut codec = ClientCodec::new(conn, None);
 
     println!("Connected, will send request");
     codec

--- a/monoio-http/examples/post_client.rs
+++ b/monoio-http/examples/post_client.rs
@@ -40,7 +40,7 @@ async fn main() {
         .expect("unable to connect");
     let (r, w) = conn.into_split();
     let mut sender = GenericEncoder::new(w);
-    let mut receiver = ResponseDecoder::new(r);
+    let mut receiver = ResponseDecoder::new(r, None);
 
     println!("Connected, will send request");
     sender

--- a/monoio-http/examples/post_client_chunked.rs
+++ b/monoio-http/examples/post_client_chunked.rs
@@ -38,7 +38,7 @@ async fn main() {
         .expect("unable to connect");
     let (r, w) = conn.into_split();
     let mut sender = GenericEncoder::new(w);
-    let mut receiver = ResponseDecoder::new(r);
+    let mut receiver = ResponseDecoder::new(r, None);
     println!("Connected, will send request");
 
     monoio::spawn(async move {

--- a/monoio-http/src/h1/codec/client.rs
+++ b/monoio-http/src/h1/codec/client.rs
@@ -1,3 +1,4 @@
+use std::time::Duration;
 use monoio::io::{
     sink::Sink, stream::Stream, AsyncReadRent, AsyncWriteRent, OwnedReadHalf, OwnedWriteHalf,
     Split, Splitable,
@@ -13,12 +14,12 @@ pub struct ClientCodec<IO: AsyncWriteRent> {
 }
 
 impl<IO: Split + AsyncReadRent + AsyncWriteRent> ClientCodec<IO> {
-    pub fn new(io: IO) -> Self {
+    pub fn new(io: IO, timeout: Option<Duration>) -> Self {
         // # Safety: Since we will not use the encoder and decoder at once, we can split it safely.
         let (r, w) = io.into_split();
         Self {
             encoder: GenericEncoder::new(w),
-            decoder: ClientResponseDecoder::new(r),
+            decoder: ClientResponseDecoder::new(r, timeout),
         }
     }
 }

--- a/monoio-http/src/h1/codec/server.rs
+++ b/monoio-http/src/h1/codec/server.rs
@@ -1,3 +1,4 @@
+use std::time::Duration;
 use monoio::io::{
     sink::Sink, stream::Stream, AsyncReadRent, AsyncWriteRent, OwnedReadHalf, OwnedWriteHalf,
     Split, Splitable,
@@ -14,12 +15,12 @@ pub struct ServerCodec<IO: AsyncWriteRent> {
 }
 
 impl<IO: Split + AsyncReadRent + AsyncWriteRent> ServerCodec<IO> {
-    pub fn new(io: IO) -> Self {
+    pub fn new(io: IO, timeout: Option<Duration>) -> Self {
         // # Safety: Since we will not use the encoder and decoder at once, we can split it safely.
         let (r, w) = io.into_split();
         Self {
             encoder: GenericEncoder::new(w),
-            decoder: RequestDecoder::new(r),
+            decoder: RequestDecoder::new(r, timeout),
         }
     }
 }


### PR DESCRIPTION
use framed.peek_data() to wait on the first byte from decoder.