### PR TITLE
feat: allow construct RequestRef from &http::Request

### DIFF
--- a/monoio-http/src/common/body.rs
+++ b/monoio-http/src/common/body.rs
@@ -37,6 +37,21 @@ pub trait Body {
     fn stream_hint(&self) -> StreamHint;
 }
 
+impl<T: Body> Body for &mut T {
+    type Data = T::Data;
+    type Error = T::Error;
+
+    #[inline]
+    fn next_data(&mut self) -> impl Future<Output = Option<Result<Self::Data, Self::Error>>> {
+        (**self).next_data()
+    }
+
+    #[inline]
+    fn stream_hint(&self) -> StreamHint {
+        (**self).stream_hint()
+    }
+}
+
 pub type Chunks = SmallVec<[Bytes; 16]>;
 
 pub trait BodyExt: Body {

--- a/monoio-http/src/common/mod.rs
+++ b/monoio-http/src/common/mod.rs
@@ -24,5 +24,18 @@ pub trait IntoParts {
 
 pub trait BorrowHeaderMap {
     fn header_map(&self) -> &http::HeaderMap;
-    fn header_map_mut(&mut self) -> &mut http::HeaderMap;
+}
+
+impl<T: BorrowHeaderMap> BorrowHeaderMap for &T {
+    #[inline]
+    fn header_map(&self) -> &http::HeaderMap {
+        (**self).header_map()
+    }
+}
+
+impl BorrowHeaderMap for http::HeaderMap<http::HeaderValue> {
+    #[inline]
+    fn header_map(&self) -> &http::HeaderMap {
+        self
+    }
 }

--- a/monoio-http/src/common/request.rs
+++ b/monoio-http/src/common/request.rs
@@ -9,6 +9,7 @@ use crate::{
 pub type Request<P = Payload> = http::request::Request<P>;
 
 impl<P> FromParts<RequestHead, P> for Request<P> {
+    #[inline]
     fn from_parts(parts: RequestHead, body: P) -> Self {
         Self::from_parts(parts, body)
     }
@@ -17,46 +18,55 @@ impl<P> FromParts<RequestHead, P> for Request<P> {
 impl<P> IntoParts for Request<P> {
     type Parts = RequestHead;
     type Body = P;
+    #[inline]
     fn into_parts(self) -> (Self::Parts, Self::Body) {
         self.into_parts()
     }
 }
 
-pub struct RequestForEncoder<'a, P = Payload> {
-    parts: &'a mut RequestHead,
-    body: P,
+pub struct RequestHeadRef<'a> {
+    pub method: &'a http::Method,
+    pub uri: &'a http::Uri,
+    pub version: http::Version,
+    pub headers: &'a http::HeaderMap,
 }
 
-impl<'a, P> FromParts<&'a mut RequestHead, P> for RequestForEncoder<'a, P> {
-    fn from_parts(parts: &'a mut RequestHead, body: P) -> Self {
+impl<'a> RequestHeadRef<'a> {
+    #[inline]
+    pub fn from_http<B>(req: &'a http::Request<B>) -> Self {
+        Self {
+            method: req.method(),
+            uri: req.uri(),
+            version: req.version(),
+            headers: req.headers(),
+        }
+    }
+}
+
+pub struct RequestRef<'a, B = Payload> {
+    pub parts: RequestHeadRef<'a>,
+    pub body: B,
+}
+
+impl<'a, B> FromParts<RequestHeadRef<'a>, B> for RequestRef<'a, B> {
+    #[inline]
+    fn from_parts(parts: RequestHeadRef<'a>, body: B) -> Self {
         Self { parts, body }
     }
 }
 
-impl<'a, P> IntoParts for RequestForEncoder<'a, P> {
-    type Parts = &'a mut RequestHead;
-    type Body = P;
+impl<'a, B> IntoParts for RequestRef<'a, B> {
+    type Parts = RequestHeadRef<'a>;
+    type Body = B;
+    #[inline]
     fn into_parts(self) -> (Self::Parts, Self::Body) {
         (self.parts, self.body)
     }
 }
 
 impl BorrowHeaderMap for RequestHead {
+    #[inline]
     fn header_map(&self) -> &http::HeaderMap {
         &self.headers
-    }
-
-    fn header_map_mut(&mut self) -> &mut http::HeaderMap {
-        &mut self.headers
-    }
-}
-
-impl BorrowHeaderMap for &mut RequestHead {
-    fn header_map(&self) -> &http::HeaderMap {
-        &self.headers
-    }
-
-    fn header_map_mut(&mut self) -> &mut http::HeaderMap {
-        &mut self.headers
     }
 }

--- a/monoio-http/src/common/response.rs
+++ b/monoio-http/src/common/response.rs
@@ -9,6 +9,7 @@ use crate::{
 pub type Response<P = Payload> = http::response::Response<P>;
 
 impl<P> FromParts<ResponseHead, P> for Response<P> {
+    #[inline]
     fn from_parts(parts: ResponseHead, body: P) -> Self {
         Self::from_parts(parts, body)
     }
@@ -17,17 +18,22 @@ impl<P> FromParts<ResponseHead, P> for Response<P> {
 impl<P> IntoParts for Response<P> {
     type Parts = ResponseHead;
     type Body = P;
+    #[inline]
     fn into_parts(self) -> (Self::Parts, Self::Body) {
         self.into_parts()
     }
 }
 
+pub struct ResponseHeadRef<'a> {
+    pub status: http::StatusCode,
+    pub version: http::Version,
+    pub headers: &'a http::HeaderMap<http::HeaderValue>,
+    pub extensions: &'a http::Extensions,
+}
+
 impl BorrowHeaderMap for ResponseHead {
+    #[inline]
     fn header_map(&self) -> &http::HeaderMap {
         &self.headers
-    }
-
-    fn header_map_mut(&mut self) -> &mut http::HeaderMap {
-        &mut self.headers
     }
 }

--- a/monoio-http/src/h1/codec/encoder.rs
+++ b/monoio-http/src/h1/codec/encoder.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Write, io};
 
 use bytes::{BufMut, BytesMut};
-use http::{HeaderMap, HeaderValue, StatusCode, Version};
+use http::{StatusCode, Version};
 use monoio::{
     buf::IoBuf,
     io::{sink::Sink, AsyncWriteRent, AsyncWriteRentExt},
@@ -14,9 +14,9 @@ use crate::{
         body::{Body, StreamHint},
         error::HttpError,
         ext::Reason,
-        request::RequestHead,
-        response::ResponseHead,
-        BorrowHeaderMap, IntoParts,
+        request::{RequestHead, RequestHeadRef},
+        response::{ResponseHead, ResponseHeadRef},
+        IntoParts,
     },
     h1::payload::PayloadError,
 };
@@ -42,20 +42,22 @@ impl Clone for EncodeError {
     }
 }
 
-struct HeadEncoder;
+struct HeadEncoder(pub Length);
 
 impl HeadEncoder {
-    fn set_length_header(header_map: &mut HeaderMap, length: Length) {
-        match length {
+    #[inline]
+    fn write_length(&self, dst: &mut BytesMut) {
+        match self.0 {
             Length::None => (),
             Length::ContentLength(l) => {
-                header_map.insert(http::header::CONTENT_LENGTH, l.into());
+                dst.extend_from_slice(http::header::CONTENT_LENGTH.as_ref());
+                dst.extend_from_slice(b": ");
+                let _ = write!(dst, "{l}");
+                dst.extend_from_slice(b"\r\n");
             }
             Length::Chunked => {
-                header_map.insert(
-                    http::header::TRANSFER_ENCODING,
-                    HeaderValue::from_static("chunked"),
-                );
+                dst.extend_from_slice(http::header::TRANSFER_ENCODING.as_ref());
+                dst.extend_from_slice(b": chunked\r\n");
             }
         }
     }
@@ -64,35 +66,63 @@ impl HeadEncoder {
 impl Encoder<RequestHead> for HeadEncoder {
     type Error = io::Error;
 
-    fn encode(&mut self, mut item: RequestHead, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        self.encode(&mut item, dst)
+    #[inline]
+    fn encode(&mut self, item: RequestHead, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        self.encode((&item.method, &item.uri, item.version, &item.headers), dst)
     }
 }
 
-impl Encoder<&mut RequestHead> for HeadEncoder {
+impl Encoder<&RequestHead> for HeadEncoder {
+    type Error = io::Error;
+
+    #[inline]
+    fn encode(&mut self, item: &RequestHead, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        self.encode((&item.method, &item.uri, item.version, &item.headers), dst)
+    }
+}
+
+impl<'a> Encoder<RequestHeadRef<'a>> for HeadEncoder {
+    type Error = io::Error;
+
+    #[inline]
+    fn encode(&mut self, item: RequestHeadRef<'a>, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        self.encode((item.method, item.uri, item.version, item.headers), dst)
+    }
+}
+
+impl<'a> Encoder<&RequestHeadRef<'a>> for HeadEncoder {
+    type Error = io::Error;
+
+    #[inline]
+    fn encode(&mut self, item: &RequestHeadRef<'a>, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        self.encode((item.method, item.uri, item.version, item.headers), dst)
+    }
+}
+
+impl Encoder<(&http::Method, &http::Uri, http::Version, &http::HeaderMap)> for HeadEncoder {
     type Error = io::Error;
 
     fn encode(
         &mut self,
-        item: &mut RequestHead,
-        dst: &mut bytes::BytesMut,
+        item: (&http::Method, &http::Uri, http::Version, &http::HeaderMap),
+        dst: &mut BytesMut,
     ) -> Result<(), Self::Error> {
+        let (method, uri, version, headers) = item;
         // TODO: magic number here
-        dst.reserve(256 + item.headers.len() * AVERAGE_HEADER_SIZE);
+        dst.reserve(256 + headers.len() * AVERAGE_HEADER_SIZE);
         // put http method
-        dst.extend_from_slice(item.method.as_str().as_bytes());
+        dst.extend_from_slice(method.as_str().as_bytes());
         dst.extend_from_slice(b" ");
         // put path
         dst.extend_from_slice(
-            item.uri
-                .path_and_query()
+            uri.path_and_query()
                 .map(|u| u.as_str())
                 .unwrap_or("/")
                 .as_bytes(),
         );
         dst.extend_from_slice(b" ");
         // put version
-        let ver = match item.version {
+        let ver = match version {
             Version::HTTP_09 => b"HTTP/0.9\r\n",
             Version::HTTP_10 => b"HTTP/1.0\r\n",
             Version::HTTP_11 => b"HTTP/1.1\r\n",
@@ -102,8 +132,14 @@ impl Encoder<&mut RequestHead> for HeadEncoder {
         };
         dst.extend_from_slice(ver);
 
+        // put content length or transfor encoding
+        // note: should remote these headers if cannot guarantee these 2 header not exist.
+        self.write_length(dst);
+
         // put headers
-        for (name, value) in item.headers.iter() {
+        for (name, value) in headers.iter().filter(|(name, _)| {
+            *name != http::header::CONTENT_LENGTH && *name != http::header::TRANSFER_ENCODING
+        }) {
             dst.extend_from_slice(name.as_ref());
             dst.extend_from_slice(b": ");
             dst.extend_from_slice(value.as_ref());
@@ -117,29 +153,86 @@ impl Encoder<&mut RequestHead> for HeadEncoder {
 impl Encoder<ResponseHead> for HeadEncoder {
     type Error = io::Error;
 
+    #[inline]
     fn encode(&mut self, item: ResponseHead, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        self.encode(&item, dst)
+        self.encode(
+            (item.status, item.version, &item.headers, &item.extensions),
+            dst,
+        )
     }
 }
 
 impl Encoder<&ResponseHead> for HeadEncoder {
     type Error = io::Error;
 
+    #[inline]
+    fn encode(&mut self, item: &ResponseHead, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        self.encode(
+            (item.status, item.version, &item.headers, &item.extensions),
+            dst,
+        )
+    }
+}
+
+impl<'a> Encoder<ResponseHeadRef<'a>> for HeadEncoder {
+    type Error = io::Error;
+
+    #[inline]
+    fn encode(&mut self, item: ResponseHeadRef<'a>, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        self.encode(
+            (item.status, item.version, item.headers, item.extensions),
+            dst,
+        )
+    }
+}
+
+impl<'a> Encoder<&ResponseHeadRef<'a>> for HeadEncoder {
+    type Error = io::Error;
+
+    #[inline]
     fn encode(
         &mut self,
-        item: &ResponseHead,
+        item: &ResponseHeadRef<'a>,
+        dst: &mut BytesMut,
+    ) -> Result<(), Self::Error> {
+        self.encode(
+            (item.status, item.version, item.headers, item.extensions),
+            dst,
+        )
+    }
+}
+
+impl
+    Encoder<(
+        http::StatusCode,
+        http::Version,
+        &http::HeaderMap<http::HeaderValue>,
+        &http::Extensions,
+    )> for HeadEncoder
+{
+    type Error = io::Error;
+
+    fn encode(
+        &mut self,
+        item: (
+            http::StatusCode,
+            http::Version,
+            &http::HeaderMap<http::HeaderValue>,
+            &http::Extensions,
+        ),
         dst: &mut bytes::BytesMut,
     ) -> Result<(), Self::Error> {
+        let (status, version, headers, extensions) = item;
         // TODO: magic number here
-        dst.reserve(256 + item.headers.len() * AVERAGE_HEADER_SIZE);
+        dst.reserve(256 + headers.len() * AVERAGE_HEADER_SIZE);
         // put version
-        if item.version == Version::HTTP_11
-            && item.status == StatusCode::OK
-            && item.extensions.get::<Reason>().is_none()
+        if version == Version::HTTP_11
+            && status == StatusCode::OK
+            && extensions.get::<Reason>().is_none()
         {
             dst.extend_from_slice(b"HTTP/1.1 200 OK\r\n");
         } else {
-            let ver = match item.version {
+            let ver = match version {
                 Version::HTTP_11 => b"HTTP/1.1 ",
                 Version::HTTP_10 => b"HTTP/1.0 ",
                 Version::HTTP_09 => b"HTTP/0.9 ",
@@ -152,23 +245,25 @@ impl Encoder<&ResponseHead> for HeadEncoder {
             };
             dst.extend_from_slice(ver);
             // put status code
-            dst.extend_from_slice(item.status.as_str().as_bytes());
+            dst.extend_from_slice(status.as_str().as_bytes());
             dst.extend_from_slice(b" ");
             // put reason
-            let reason = match item.extensions.get::<Reason>() {
+            let reason = match extensions.get::<Reason>() {
                 Some(reason) => reason.as_bytes(),
-                None => item
-                    .status
-                    .canonical_reason()
-                    .unwrap_or("<none>")
-                    .as_bytes(),
+                None => status.canonical_reason().unwrap_or("<none>").as_bytes(),
             };
             dst.extend_from_slice(reason);
             dst.extend_from_slice(b"\r\n");
         }
 
+        // put content length or transfor encoding
+        // note: should remote these headers if cannot guarantee these 2 header not exist.
+        self.write_length(dst);
+
         // put headers
-        for (name, value) in item.headers.iter() {
+        for (name, value) in headers.iter().filter(|(name, _)| {
+            *name != http::header::CONTENT_LENGTH && *name != http::header::TRANSFER_ENCODING
+        }) {
             dst.extend_from_slice(name.as_ref());
             dst.extend_from_slice(b": ");
             dst.extend_from_slice(value.as_ref());
@@ -248,7 +343,6 @@ impl<T, R> Sink<R> for GenericEncoder<T>
 where
     T: AsyncWriteRent,
     R: IntoParts,
-    R::Parts: BorrowHeaderMap,
     R::Body: Body,
     HeadEncoder: Encoder<R::Parts>,
     <HeadEncoder as Encoder<R::Parts>>::Error: Into<EncodeError>,
@@ -257,23 +351,19 @@ where
     type Error = HttpError;
 
     async fn send(&mut self, item: R) -> Result<(), Self::Error> {
-        let (mut head, mut payload) = item.into_parts();
+        let (head, mut payload) = item.into_parts();
 
         // if there is too much content in buffer, flush it first
         if self.buf.len() > BACKPRESSURE_BOUNDARY {
             Sink::<R>::flush(self).await?;
         }
-        let header_map = head.header_map_mut();
         let payload_type = payload.stream_hint();
 
         match payload_type {
             StreamHint::None => {
-                // set special header
-                HeadEncoder::set_length_header(header_map, Length::None);
+                let mut encoder = HeadEncoder(Length::None);
                 // encode head to buffer
-                HeadEncoder
-                    .encode(head, &mut self.buf)
-                    .map_err(Into::into)?;
+                encoder.encode(head, &mut self.buf).map_err(Into::into)?;
             }
             StreamHint::Fixed => {
                 // get data(to set content length and body)
@@ -281,15 +371,9 @@ where
                     .next_data()
                     .await
                     .expect("empty data with fixed hint")?;
-                // set special header
-                HeadEncoder::set_length_header(
-                    header_map,
-                    Length::ContentLength(data.bytes_init()),
-                );
+                let mut encoder = HeadEncoder(Length::ContentLength(data.bytes_init()));
                 // encode head to buffer
-                HeadEncoder
-                    .encode(head, &mut self.buf)
-                    .map_err(Into::into)?;
+                encoder.encode(head, &mut self.buf).map_err(Into::into)?;
                 // flush
                 if self.buf.len() + data.bytes_init() > BACKPRESSURE_BOUNDARY {
                     // if data to send is too long, we will flush the buffer
@@ -306,12 +390,9 @@ where
                 }
             }
             StreamHint::Stream => {
-                // set special header
-                HeadEncoder::set_length_header(header_map, Length::Chunked);
+                let mut encoder = HeadEncoder(Length::Chunked);
                 // encode head to buffer
-                HeadEncoder
-                    .encode(head, &mut self.buf)
-                    .map_err(Into::into)?;
+                encoder.encode(head, &mut self.buf).map_err(Into::into)?;
 
                 while let Some(data_res) = payload.next_data().await {
                     let data = data_res?;


### PR DESCRIPTION
Previously:
1. `HeadEncoder` can only encode `http::Parts` and `&mut http::Parts`, however, we cannot get any of these without calling `into_parts` and consume the Request. So it is hard to encode a request without getting its ownership.
2. `RequestForEncoder` can only construct from `&http::Parts`, due to the same reason, we cannot construct it.

What's in this PR:
1. Implement `Encoder<(&http::Method, &http::Uri, http::Version, &http::HeaderMap)>` and `Encoder<(http::StatusCode, http::Version, &http::HeaderMap<http::HeaderValue>, &http::Extensions)>` for HeadEncoder, and based on these 2 mothods, implement `Encoder<RequestHeadRef>` and `Encoder<ResponseHeadRef>`.
2. Rename `RequestForEncoder` to `RequestRef` and use `RequestHeadRef` to replace http::Parts, which can be constructed directly or from `&http::Request`.