### PR TITLE
Feat: Async multipart parsing with multer, on disk caching for large files, ParsedMultiPartFrom to HttpBody conversion

### DIFF
--- a/monoio-http/Cargo.toml
+++ b/monoio-http/Cargo.toml
@@ -24,10 +24,8 @@ local-sync = { workspace = true }
 thiserror = { workspace = true }
 cookie = { version = "0.18.0", features = ["percent-encode"] }
 serde_urlencoded = "0.7"
-multipart = "0.18"
 mime = "0.3"
 multer = "3.0.0"
-tempfile = "3.10.1"
 
 httparse = "1"
 memchr = "2.5"

--- a/monoio-http/Cargo.toml
+++ b/monoio-http/Cargo.toml
@@ -27,6 +27,7 @@ serde_urlencoded = "0.7"
 multipart = "0.18"
 mime = "0.3"
 multer = "3.0.0"
+tempfile = "3.10.1"
 
 httparse = "1"
 memchr = "2.5"

--- a/monoio-http/src/common/body.rs
+++ b/monoio-http/src/common/body.rs
@@ -197,6 +197,7 @@ pub enum HttpBody {
     Ready(Option<Bytes>),
     H1(Payload),
     H2(RecvStream),
+    Multipart(ParsedMuliPartForm)
 }
 
 impl HttpBody {
@@ -292,6 +293,7 @@ impl Body for HttpBody {
             Self::Ready(b) => b.take().map(Result::Ok),
             Self::H1(ref mut p) => p.next_data().await,
             Self::H2(ref mut p) => p.next_data().await.map(|r| r.map_err(HttpError::from)),
+            Self::Multipart(ref mut p) => p.next_data().await,
         }
     }
 
@@ -301,6 +303,7 @@ impl Body for HttpBody {
             Self::Ready(None) => StreamHint::None,
             Self::H1(ref p) => p.stream_hint(),
             Self::H2(ref p) => p.stream_hint(),
+            Self::Multipart(ref p) => p.stream_hint(),
         }
     }
 }
@@ -314,6 +317,7 @@ impl FixedBody for HttpBody {
         Self::Ready(data)
     }
 }
+
 
 #[derive(Debug)]
 pub struct HttpBodyStream {

--- a/monoio-http/src/common/body.rs
+++ b/monoio-http/src/common/body.rs
@@ -305,32 +305,6 @@ impl Body for HttpBody {
     }
 }
 
-impl futures_core::Stream for HttpBody {
-    type Item = Result<Bytes, HttpError>;
-
-    fn poll_next(
-        self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context,
-    ) -> std::task::Poll<Option<Self::Item>> {
-        match self.get_mut() {
-            Self::Ready(b) => {
-                let b = b.take();
-                std::task::Poll::Ready(b.map(Ok))
-            }
-            Self::H1(p) => {
-                let p = pin!(p.next_data());
-                p.poll(cx)
-            }
-            Self::H2(p) => {
-                let p = pin!(p.next_data());
-                p.poll(cx).map_err(|e| HttpError::from(e))
-            }
-        }
-    }
-}
-
-unsafe impl Send for HttpBody {}
-
 pub trait FixedBody: Body {
     fn fixed_body(data: Option<Bytes>) -> Self;
 }

--- a/monoio-http/src/common/body.rs
+++ b/monoio-http/src/common/body.rs
@@ -197,7 +197,7 @@ pub enum HttpBody {
     Ready(Option<Bytes>),
     H1(Payload),
     H2(RecvStream),
-    Multipart(ParsedMuliPartForm)
+    Multipart(ParsedMuliPartForm),
 }
 
 impl HttpBody {
@@ -317,7 +317,6 @@ impl FixedBody for HttpBody {
         Self::Ready(data)
     }
 }
-
 
 #[derive(Debug)]
 pub struct HttpBodyStream {

--- a/monoio-http/src/common/body.rs
+++ b/monoio-http/src/common/body.rs
@@ -14,7 +14,10 @@ use monoio::buf::IoBuf;
 use monoio_compat::box_future::MaybeArmedBoxFuture;
 use smallvec::SmallVec;
 
-use super::error::{EncodeDecodeError, HttpError};
+use super::{
+    error::{EncodeDecodeError, HttpError},
+    multipart::ParsedMuliPartForm,
+};
 use crate::{
     common::{request::Request, response::Response},
     h1::payload::Payload,

--- a/monoio-http/src/common/body.rs
+++ b/monoio-http/src/common/body.rs
@@ -16,7 +16,7 @@ use smallvec::SmallVec;
 
 use super::{
     error::{EncodeDecodeError, HttpError},
-    multipart::ParsedMuliPartForm,
+    multipart::ParsedMultiPartForm,
 };
 use crate::{
     common::{request::Request, response::Response},
@@ -200,7 +200,7 @@ pub enum HttpBody {
     Ready(Option<Bytes>),
     H1(Payload),
     H2(RecvStream),
-    Multipart(ParsedMuliPartForm),
+    Multipart(ParsedMultiPartForm),
 }
 
 impl HttpBody {

--- a/monoio-http/src/common/body.rs
+++ b/monoio-http/src/common/body.rs
@@ -305,6 +305,32 @@ impl Body for HttpBody {
     }
 }
 
+impl futures_core::Stream for HttpBody {
+    type Item = Result<Bytes, HttpError>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        match self.get_mut() {
+            Self::Ready(b) => {
+                let b = b.take();
+                std::task::Poll::Ready(b.map(Ok))
+            }
+            Self::H1(p) => {
+                let p = pin!(p.next_data());
+                p.poll(cx)
+            }
+            Self::H2(p) => {
+                let p = pin!(p.next_data());
+                p.poll(cx).map_err(|e| HttpError::from(e))
+            }
+        }
+    }
+}
+
+unsafe impl Send for HttpBody {}
+
 pub trait FixedBody: Body {
     fn fixed_body(data: Option<Bytes>) -> Self;
 }

--- a/monoio-http/src/common/error.rs
+++ b/monoio-http/src/common/error.rs
@@ -39,7 +39,6 @@ pub enum HttpError {
     SerDeError(#[from] serde_urlencoded::de::Error),
     #[error("Multer Error")]
     MulterError(#[from] multer::Error),
- 
 }
 
 impl Clone for HttpError {

--- a/monoio-http/src/common/error.rs
+++ b/monoio-http/src/common/error.rs
@@ -37,6 +37,9 @@ pub enum HttpError {
     CookieError(#[from] ExtractError),
     #[error("SerDe error {0}")]
     SerDeError(#[from] serde_urlencoded::de::Error),
+    #[error("Multer Error")]
+    MulterError(#[from] multer::Error),
+ 
 }
 
 impl Clone for HttpError {

--- a/monoio-http/src/common/mod.rs
+++ b/monoio-http/src/common/mod.rs
@@ -78,7 +78,7 @@ impl<T> Parse<T> {
     }
 
     #[inline]
-    pub fn parsed_inner(&self) -> &T {
+    pub fn parsed_inner_ref(&self) -> &T {
         match self {
             Parse::Parsed(inner) => inner,
             _ => unsafe { std::hint::unreachable_unchecked() },
@@ -87,6 +87,14 @@ impl<T> Parse<T> {
 
     #[inline]
     pub fn parsed_inner_mut(&mut self) -> &mut T {
+        match self {
+            Parse::Parsed(inner) => inner,
+            _ => unsafe { std::hint::unreachable_unchecked() },
+        }
+    }
+
+    #[inline]
+    pub fn parsed_inner(self) ->  T {
         match self {
             Parse::Parsed(inner) => inner,
             _ => unsafe { std::hint::unreachable_unchecked() },

--- a/monoio-http/src/common/mod.rs
+++ b/monoio-http/src/common/mod.rs
@@ -9,6 +9,7 @@ pub mod parsed_request;
 pub mod parsed_response;
 pub mod request;
 pub mod response;
+pub mod multipart;
 
 pub(crate) mod waker;
 

--- a/monoio-http/src/common/mod.rs
+++ b/monoio-http/src/common/mod.rs
@@ -5,11 +5,11 @@ use bytes::Bytes;
 pub mod body;
 pub mod error;
 pub mod ext;
+pub mod multipart;
 pub mod parsed_request;
 pub mod parsed_response;
 pub mod request;
 pub mod response;
-pub mod multipart;
 
 pub(crate) mod waker;
 
@@ -78,6 +78,11 @@ impl<T> Parse<T> {
     }
 
     #[inline]
+    pub fn is_parsing_failed(&self) -> bool {
+        matches!(self, Parse::Failed)
+    }
+
+    #[inline]
     pub fn parsed_inner_ref(&self) -> &T {
         match self {
             Parse::Parsed(inner) => inner,
@@ -94,7 +99,7 @@ impl<T> Parse<T> {
     }
 
     #[inline]
-    pub fn parsed_inner(self) ->  T {
+    pub fn parsed_inner(self) -> T {
         match self {
             Parse::Parsed(inner) => inner,
             _ => unsafe { std::hint::unreachable_unchecked() },

--- a/monoio-http/src/common/multipart.rs
+++ b/monoio-http/src/common/multipart.rs
@@ -35,7 +35,7 @@ pub struct FieldHeader {
 }
 
 #[derive(Debug)]
-pub struct ParsedMuliPartForm {
+pub struct ParsedMultiPartForm {
     value: HashMap<String, Vec<FieldHeader>>,
     file: HashMap<String, Vec<FileHeader>>,
     boundary: String,
@@ -71,13 +71,13 @@ impl FileHeader {
     }
 }
 
-impl From<ParsedMuliPartForm> for HttpBody {
-    fn from(p: ParsedMuliPartForm) -> Self {
+impl From<ParsedMultiPartForm> for HttpBody {
+    fn from(p: ParsedMultiPartForm) -> Self {
         Self::Multipart(p)
     }
 }
 
-impl ParsedMuliPartForm {
+impl ParsedMultiPartForm {
     pub fn new(boundary: String, max_file_size: u64) -> Self {
         Self {
             value: HashMap::new(),
@@ -131,6 +131,14 @@ impl ParsedMuliPartForm {
                 })
                 .collect()
         })
+    }
+
+    pub fn get_fields_keys(&self) -> Vec<String> {
+        self.value.keys().cloned().collect()
+    }
+
+    pub fn get_files_keys(&self) -> Vec<String> {
+        self.file.keys().cloned().collect()
     }
 
     fn get_next_file_key(&self) -> Option<String> {
@@ -230,7 +238,7 @@ impl ParsedMuliPartForm {
         boundary: String,
         max_file_size: u64,
     ) -> Result<Self, HttpError> {
-        let mut form = ParsedMuliPartForm::new(boundary, max_file_size);
+        let mut form = ParsedMultiPartForm::new(boundary, max_file_size);
         while let Some(mut field) = multer_multipart.next_field().await? {
             let name = field.name().unwrap_or_default().to_string();
             let file_name = field.file_name().unwrap_or("").to_string();
@@ -276,7 +284,7 @@ impl ParsedMuliPartForm {
     }
 }
 
-impl Body for ParsedMuliPartForm {
+impl Body for ParsedMultiPartForm {
     type Data = Bytes;
     type Error = HttpError;
 

--- a/monoio-http/src/common/multipart.rs
+++ b/monoio-http/src/common/multipart.rs
@@ -1,0 +1,98 @@
+use std::{collections::HashMap, io::{Cursor, Read, Write} };
+
+use bytes::{Bytes, BytesMut};
+use http::HeaderMap;
+use tempfile::NamedTempFile;
+
+use super::error::HttpError;
+
+enum  Data {
+    InMemory(Cursor<Bytes>),
+    InFile(NamedTempFile)
+}
+
+pub struct FileHeader {
+    filename: String,
+    headers: HeaderMap,
+    size: usize,
+    data: Data 
+}
+
+pub struct ParsedMuliPartForm {
+    value: HashMap<String, Vec<String>>,
+    file: HashMap<String, Vec<FileHeader>>,
+}
+
+impl Read for Data {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            Data::InMemory(cursor) => cursor.read(buf),
+            Data::InFile(file) => file.read(buf),
+        }
+    }
+}
+
+impl ParsedMuliPartForm {
+    pub fn new() -> Self {
+        Self {
+            value: HashMap::new(),
+            file: HashMap::new(),
+        }
+    }
+
+    fn insert_value(&mut self, key: String, value: String) {
+        self.value.entry(key).or_insert_with(Vec::new).push(value);
+    }
+
+    fn insert_file(&mut self, key: String, file: FileHeader) {
+        self.file.entry(key).or_insert_with(Vec::new).push(file);
+    }
+
+    fn insert_file_data(&mut self, key: String, filename: String, headers: HeaderMap, size: usize, data: Data) {
+        self.insert_file(key, FileHeader { filename, headers, size, data });
+    }
+
+    async fn read_form(mut multer_multipart: multer::Multipart<'_>) -> Result<Self, HttpError>{
+        let mut form = ParsedMuliPartForm::new();
+        while let Some(mut field) = multer_multipart.next_field().await? {
+
+            let name = field.name().unwrap_or_default().to_string();
+            let file_name = field.file_name().unwrap_or_else(|| "").to_string();
+            let headers = field.headers().clone();
+
+            if file_name == "" {
+                let value = field.bytes().await?.to_vec();
+                let value = String::from_utf8_lossy(&value).to_string();
+                form.insert_value(name, value);
+                continue;
+            }
+
+            
+            let mut buf = BytesMut::new();
+            while let Some(bytes) = field.chunk().await? {
+                buf.extend_from_slice(&bytes);
+            }
+
+            let MAX_FILE_SIZE = 10 * 1024 * 1024;
+            let file_size = buf.len();
+
+            let data = if  file_size > MAX_FILE_SIZE {
+                let temp_file = tempfile::NamedTempFile::new().unwrap();
+                let mut file = temp_file.reopen()?;
+                file.write_all(&buf)?;
+                file.flush()?;
+                Data::InFile(temp_file)
+            } else {
+                let cursor = Cursor::new(buf.freeze());
+                Data::InMemory(cursor)
+            };
+            form.insert_file_data(name, file_name, headers, file_size, data);
+        }
+
+        Ok(form)
+    }
+
+}
+
+
+

--- a/monoio-http/src/common/multipart.rs
+++ b/monoio-http/src/common/multipart.rs
@@ -1,16 +1,18 @@
-use std::{collections::HashMap, io::{Cursor, Read, Write} };
+use std::{collections::HashMap, io::{ Read, Write}, path::PathBuf };
 
 use bytes::{Bytes, BytesMut};
 use http::HeaderMap;
 use tempfile::NamedTempFile;
 
-use super::error::HttpError;
+use super::{body::{Body, HttpBody, StreamHint}, error::HttpError};
 
+#[derive(Debug)]
 enum  Data {
-    InMemory(Cursor<Bytes>),
+    InMemory(Bytes),
     InFile(NamedTempFile)
 }
 
+#[derive(Debug)]
 pub struct FileHeader {
     filename: String,
     headers: HeaderMap,
@@ -18,30 +20,78 @@ pub struct FileHeader {
     data: Data 
 }
 
-pub struct ParsedMuliPartForm {
-    value: HashMap<String, Vec<String>>,
-    file: HashMap<String, Vec<FileHeader>>,
+#[derive(Debug)]
+pub enum RetData {
+    InMemory(Bytes),
+    InFile(PathBuf)
 }
 
-impl Read for Data {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        match self {
-            Data::InMemory(cursor) => cursor.read(buf),
-            Data::InFile(file) => file.read(buf),
-        }
+#[derive(Debug)]
+pub struct RetFileHeader {
+    filename: String,
+    headers: HeaderMap,
+    data: RetData 
+}
+
+#[derive(Debug, Clone)]
+pub struct FieldHeader {
+    pub value: String,
+    pub headers: HeaderMap
+}
+
+
+#[derive(Debug)]
+pub struct ParsedMuliPartForm {
+    value: HashMap<String, Vec<FieldHeader>>,
+    file: HashMap<String, Vec<FileHeader>>,
+    boundary: String,
+    first_part: bool,
+    closed: bool
+}
+
+impl FieldHeader {
+    pub fn get_value(&self) -> String {
+        self.value.clone()
+    }
+
+    pub fn get_headers(&self) -> &HeaderMap {
+        &self.headers
+    }
+}
+
+impl RetFileHeader {
+    pub fn get_filename(&self) -> String {
+        self.filename.clone()
+    }
+
+    pub fn get_headers(&self) -> &HeaderMap {
+        &self.headers
+    }
+
+    pub fn get_data(&self) -> &RetData {
+        &self.data
+    }
+}
+
+impl From<ParsedMuliPartForm> for HttpBody {
+    fn from(p: ParsedMuliPartForm) -> Self {
+        Self::Multipart(p)
     }
 }
 
 impl ParsedMuliPartForm {
-    pub fn new() -> Self {
+    pub fn new(boundary: String) -> Self {
         Self {
             value: HashMap::new(),
             file: HashMap::new(),
+            boundary,
+            first_part: true,
+            closed: false,
         }
     }
 
-    fn insert_value(&mut self, key: String, value: String) {
-        self.value.entry(key).or_insert_with(Vec::new).push(value);
+    fn insert_field_value(&mut self, key: String,  value: String, headers: HeaderMap) {
+        self.value.entry(key).or_insert_with(Vec::new).push(FieldHeader { value, headers });
     }
 
     fn insert_file(&mut self, key: String, file: FileHeader) {
@@ -52,8 +102,115 @@ impl ParsedMuliPartForm {
         self.insert_file(key, FileHeader { filename, headers, size, data });
     }
 
-    async fn read_form(mut multer_multipart: multer::Multipart<'_>) -> Result<Self, HttpError>{
-        let mut form = ParsedMuliPartForm::new();
+    pub fn  get_field_value(&self, key: &str) -> Option<Vec<FieldHeader>> {
+        self.value.get(key).map(|v| v.clone())
+    }
+
+    pub fn get_file(&self, key: &str) -> Option<Vec<RetFileHeader>> {
+        self.file.get(key).map(|v| {
+            v.iter().map(|file| {
+                let data = match &file.data {
+                    Data::InMemory(bytes) => RetData::InMemory(bytes.clone()),
+                    Data::InFile(file) => RetData::InFile(file.path().to_path_buf())
+                };
+                RetFileHeader {
+                    filename: file.filename.clone(),
+                    headers: file.headers.clone(),
+                    data
+                }
+            }).collect()
+        })
+    }
+
+    fn get_next_file(&mut self) -> Option<FileHeader> {
+        for file in self.file.values_mut() {
+            if let Some(file) = file.pop() {
+                return Some(file);
+            }
+        }
+        None
+    }
+
+    fn get_next_file_key(&self) -> Option<String> {
+        for key in self.file.keys() {
+            return Some(key.clone());
+        }
+        None
+    }
+
+    fn write_part(&self, mut buf: BytesMut, headers: HeaderMap) -> Result<BytesMut, HttpError> {
+
+        if self.first_part == false {
+            buf.extend_from_slice(format!("\r\n--{}\r\n", self.boundary).as_bytes());
+        } else {
+            buf.extend_from_slice(format!("--{}\r\n", self.boundary).as_bytes());
+        }
+
+        let mut keys = headers.keys().map(|k| k.to_string()).collect::<Vec<String>>();
+        keys.sort();
+
+        for key in keys {
+            let value = headers.get(&key.clone()).unwrap();
+            buf.extend_from_slice(format!("{}: {:?}\r\n", key, value).as_bytes());
+        }
+
+        buf.extend_from_slice("\r\n".as_bytes());
+
+        Ok(buf)
+    }
+
+    fn write_forms(&mut self) -> Result<Option<Bytes>, HttpError> {
+        let mut buf = BytesMut::new();
+        for (_, forms) in self.value.iter() {
+            for form in forms {
+                let headers = form.headers.clone(); // Store the value of form.headers in a separate variable
+                buf = self.write_part(buf, headers.clone())?;
+                buf.extend_from_slice(form.value.as_bytes());
+            } 
+        }
+
+        self.value.clear();
+
+        Ok(Some(buf.freeze()))
+    }
+
+    fn write_file(&mut self, key: String) -> Result<Option<Bytes>, HttpError> {
+        let mut buf = BytesMut::new();
+        for file in self.file.get(&key).unwrap() {
+            buf = self.write_part(buf,  file.headers.clone())?;
+
+            match &file.data {
+                Data::InMemory(bytes) => {
+                    buf.extend_from_slice(bytes.as_ref());
+                },
+                Data::InFile(file) =>  {
+                    let mut file = file.reopen()?; 
+                    let mut chunk = vec![0; 1024 * 1024]; // 1 KB chunk
+                    loop {
+                        let n = file.read(&mut chunk)?;
+                        if n == 0 {
+                            break;
+                        }
+                        buf.extend_from_slice(&chunk[..n]);
+                    }
+               }
+            };
+        }
+
+        self.file.remove(&key);
+
+        Ok(Some(buf.freeze()))
+    }
+
+    fn close_multipart(&mut self) -> Result<Option<Bytes>, HttpError> {
+        let mut buf = BytesMut::new();
+        self.closed = true;
+        buf.extend_from_slice(format!("\r\n--{}--\r\n", self.boundary).as_bytes());
+        Ok(Some(buf.freeze()))
+    }
+
+    pub async fn read_form(mut multer_multipart: multer::Multipart<'_>, boundary: String) -> Result<Self, HttpError>{
+        let mut form = ParsedMuliPartForm::new(boundary);
         while let Some(mut field) = multer_multipart.next_field().await? {
 
             let name = field.name().unwrap_or_default().to_string();
@@ -63,10 +220,9 @@ impl ParsedMuliPartForm {
             if file_name == "" {
                 let value = field.bytes().await?.to_vec();
                 let value = String::from_utf8_lossy(&value).to_string();
-                form.insert_value(name, value);
+                form.insert_field_value(name, value, headers);
                 continue;
             }
-
             
             let mut buf = BytesMut::new();
             while let Some(bytes) = field.chunk().await? {
@@ -83,16 +239,36 @@ impl ParsedMuliPartForm {
                 file.flush()?;
                 Data::InFile(temp_file)
             } else {
-                let cursor = Cursor::new(buf.freeze());
-                Data::InMemory(cursor)
+                Data::InMemory(buf.freeze())
             };
             form.insert_file_data(name, file_name, headers, file_size, data);
         }
 
         Ok(form)
     }
-
 }
 
+impl Body for ParsedMuliPartForm {
+    type Data = Bytes;
+    type Error = HttpError;
 
+    async fn next_data(&mut self) ->  Option<Result<Self::Data, Self::Error>> {
+        if self.value.len() > 0 {
+            return self.write_forms().map_or_else(|e| Some(Err(e)), |v| v.map(|v| Ok(v)));
+        }
+
+        if let Some(key) = self.get_next_file_key() {
+            return self.write_file(key).map_or_else(|e| Some(Err(e)), |v| v.map(|v| Ok(v)));;
+        }
+
+        if !self.closed && self.value.is_empty() && self.file.is_empty() {
+            return self.close_multipart().map_or_else(|e| Some(Err(e)), |v| v.map(|v| Ok(v)));;
+        }
+        None
+    }
+
+    fn stream_hint(&self) -> StreamHint {
+        StreamHint::Stream
+    }
+}
 

--- a/monoio-http/src/common/parsed_request.rs
+++ b/monoio-http/src/common/parsed_request.rs
@@ -4,8 +4,6 @@ use bytes::Bytes;
 use cookie::{Cookie, CookieJar};
 pub use http::request::{Builder as RequestBuilder, Parts as RequestHead};
 
-// use multipart::server::nickel::nickel::hyper::header::Origin;
-// use multipart::server::Multipart;
 use super::body::HttpBodyStream;
 use super::{
     body::{Body, BodyExt, FixedBody},
@@ -20,6 +18,7 @@ pub struct ParsedRequest<P> {
     cookie_jar: RefCell<Parse<CookieJar>>,
     url_params: RefCell<Parse<QueryMap>>,
     body_url_params: RefCell<Parse<QueryMap>>,
+    multipart_form: RefCell<Parse<super::multipart::ParsedMuliPartForm>>,
 }
 
 impl<P> From<Request<P>> for ParsedRequest<P> {
@@ -30,6 +29,7 @@ impl<P> From<Request<P>> for ParsedRequest<P> {
             cookie_jar: RefCell::new(Parse::Unparsed),
             url_params: RefCell::new(Parse::Unparsed),
             body_url_params: RefCell::new(Parse::Unparsed),
+            multipart_form: RefCell::new(Parse::Unparsed), 
         }
     }
 }

--- a/monoio-http/src/common/parsed_response.rs
+++ b/monoio-http/src/common/parsed_response.rs
@@ -82,7 +82,7 @@ impl<P> ParsedResponse<P> {
         }
 
         Ok(Ref::map(self.cookie_jar.borrow(), |params| {
-            params.parsed_inner()
+            params.parsed_inner_ref()
         }))
     }
 
@@ -109,7 +109,7 @@ impl<P> ParsedResponse<P> {
     fn serialize_cookies_into_header(&self) {
         if self.cookie_jar.borrow().is_parsed() {
             let jar = self.cookie_jar.borrow();
-            let jar = jar.parsed_inner();
+            let jar = jar.parsed_inner_ref();
 
             let cookies = jar
                 .iter()


### PR DESCRIPTION
- `ParsedMultipartFrom` follows https://pkg.go.dev/mime/multipart#Form API
- Files greater in size than 10MB are written to disk instead of being held in memory. Max file size configurable
- `into_multipart_body_request`: `ParsedMultipartFrom` to `HttpBody`
- Added two test cases to demonstrate usage
- Removed `Multipart ` crate, using multer exclusively now