### PR TITLE
Fix: Window size exhaustion with large bodies

### DIFF
--- a/monoio-http/src/h2/share.rs
+++ b/monoio-http/src/h2/share.rs
@@ -475,7 +475,11 @@ impl Body for RecvStream {
     type Error = crate::h2::Error;
 
     async fn next_data(&mut self) -> Option<Result<Self::Data, Self::Error>> {
-        self.data().await
+        self.data().await.map(|res| {
+            res.and_then(|bytes| {
+                self.flow_control().release_capacity(bytes.len()).map(|_| bytes)
+            })
+        })
     }
 
     fn stream_hint(&self) -> crate::common::body::StreamHint {


### PR DESCRIPTION
- Call release_capacity in RecvStream Body Trait implementation

```
➜  faas h2load -m 1 -d /home/ubuntu/faas/75K-req.txt http://192.168.122.216:10081/medium -vvv
starting benchmark...
spawning thread #0: 1 total client(s). 1 total requests
Application protocol: h2c
[stream_id=1] :status: 200
[stream_id=1] server: nginx/1.18.0 (Ubuntu)
[stream_id=1] date: Fri, 15 Mar 2024 22:44:14 GMT
[stream_id=1] content-type: text/plain
[stream_id=1] content-length: 423
progress: 100% done

finished in 3.68ms, 271.52 req/s, 143.98KB/s
requests: 1 total, 1 started, 1 done, 1 succeeded, 0 failed, 0 errored, 0 timeout
status codes: 1 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 543B (543) total, 59B (59) headers (space savings 45.87%), 423B (423) data
                     min         max         mean         sd        +/- sd
time for request:     2.76ms      2.76ms      2.76ms         0us   100.00%
time for connect:      526us       526us       526us         0us   100.00%
time to 1st byte:     3.35ms      3.35ms      3.35ms         0us   100.00%
req/s           :     290.57      290.57      290.57        0.00   100.00%
➜  faas h2load -m 1 -d /home/ubuntu/faas/photo.png http://192.168.122.216:10081/medium -vvv
starting benchmark...
spawning thread #0: 1 total client(s). 1 total requests
Application protocol: h2c
[stream_id=1] :status: 200
[stream_id=1] server: nginx/1.18.0 (Ubuntu)
[stream_id=1] date: Fri, 15 Mar 2024 22:44:31 GMT
[stream_id=1] content-type: text/plain
[stream_id=1] content-length: 423
progress: 100% done

finished in 3.06ms, 326.69 req/s, 173.24KB/s
requests: 1 total, 1 started, 1 done, 1 succeeded, 0 failed, 0 errored, 0 timeout
status codes: 1 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 543B (543) total, 59B (59) headers (space savings 45.87%), 423B (423) data
                     min         max         mean         sd        +/- sd
time for request:     2.23ms      2.23ms      2.23ms         0us   100.00%
time for connect:      414us       414us       414us         0us   100.00%
time to 1st byte:     2.70ms      2.70ms      2.70ms         0us   100.00%
req/s           :     359.21      359.21      359.21        0.00   100.00%
➜  faas du -h 75K-req.txt
76K     75K-req.txt
➜  faas du -h photo.png
68K     photo.png
```

