### PR TITLE
Feat: ParsedMultipartFrom

### DIFF
--- a/monoio-http/Cargo.toml
+++ b/monoio-http/Cargo.toml
@@ -39,7 +39,6 @@ smallvec = "1"
 
 cookie = { version = "0.18.0", features = ["percent-encode"], optional = true }
 serde_urlencoded = { version = "0.7", optional = true }
-multipart = { version = "0.18", optional = true }
 mime = { version = "0.3", optional = true }
 multer = { version = "3.0.0", optional = true }
 
@@ -67,7 +66,7 @@ stream = []
 # depends on this feature.
 unstable = []
 
-parsed = ["dep:cookie", "dep:serde_urlencoded", "dep:multipart", "dep:mime", "dep:multer"]
+parsed = ["dep:cookie", "dep:serde_urlencoded", "dep:mime", "dep:multer"]
 
 [lib]
 doctest = false

--- a/monoio-http/src/common/body.rs
+++ b/monoio-http/src/common/body.rs
@@ -311,7 +311,7 @@ impl Body for HttpBody {
             Self::H1(ref mut p) => p.next_data().await,
             Self::H2(ref mut p) => p.next_data().await.map(|r| r.map_err(HttpError::from)),
             #[cfg(feature = "parsed")]
-            Self::Multipart(ref mut p) => p.next_data().await,
+            Self::Multipart(ref mut p) => p.next_data().await.map(|r| r.map_err(HttpError::from)),
         }
     }
 

--- a/monoio-http/src/common/body.rs
+++ b/monoio-http/src/common/body.rs
@@ -16,10 +16,8 @@ use monoio_compat::box_future::MaybeArmedBoxFuture;
 use smallvec::SmallVec;
 
 use super::error::{EncodeDecodeError, HttpError};
-
 #[cfg(feature = "parsed")]
 use super::parsed::multipart::ParsedMultiPartForm;
-
 use crate::{
     common::{request::Request, response::Response},
     h1::payload::Payload,

--- a/monoio-http/src/common/body.rs
+++ b/monoio-http/src/common/body.rs
@@ -16,6 +16,10 @@ use monoio_compat::box_future::MaybeArmedBoxFuture;
 use smallvec::SmallVec;
 
 use super::error::{EncodeDecodeError, HttpError};
+
+#[cfg(feature = "parsed")]
+use super::parsed::multipart::ParsedMultiPartForm;
+
 use crate::{
     common::{request::Request, response::Response},
     h1::payload::Payload,
@@ -211,6 +215,8 @@ pub enum HttpBody {
     Ready(Option<Bytes>),
     H1(Payload),
     H2(RecvStream),
+    #[cfg(feature = "parsed")]
+    Multipart(ParsedMultiPartForm),
 }
 
 impl HttpBody {
@@ -306,6 +312,8 @@ impl Body for HttpBody {
             Self::Ready(b) => b.take().map(Result::Ok),
             Self::H1(ref mut p) => p.next_data().await,
             Self::H2(ref mut p) => p.next_data().await.map(|r| r.map_err(HttpError::from)),
+            #[cfg(feature = "parsed")]
+            Self::Multipart(ref mut p) => p.next_data().await,
         }
     }
 
@@ -315,6 +323,8 @@ impl Body for HttpBody {
             Self::Ready(None) => StreamHint::None,
             Self::H1(ref p) => p.stream_hint(),
             Self::H2(ref p) => p.stream_hint(),
+            #[cfg(feature = "parsed")]
+            Self::Multipart(ref p) => p.stream_hint(),
         }
     }
 }

--- a/monoio-http/src/common/error.rs
+++ b/monoio-http/src/common/error.rs
@@ -16,7 +16,6 @@ use crate::h1::{
 pub enum ParseError {
     #[error("Uninitialized cookie jar")]
     UninitializedCookieJar,
-    #[cfg(feature = "parsed")]
     #[error("http cookie parsing error {0}")]
     CookieParseError(#[from] cookie::ParseError),
     #[error("Invalid Header Value")]
@@ -25,12 +24,14 @@ pub enum ParseError {
     InvalidContentType,
     #[error("SerDe error {0}")]
     Serde(#[from] serde_urlencoded::de::Error),
+    #[error("Previous Error")]
+    Previous,
     #[error("http error {0}")]
     Http(#[from] HttpError),
-    #[error("Previous returned error")]
-    Previous,
     #[error("Multer Error")]
     MulterError(#[from] multer::Error),
+    #[error("IO error {0}")]
+    IOError(#[from] std::io::Error),
 }
 
 #[derive(ThisError, Debug)]
@@ -45,6 +46,9 @@ pub enum HttpError {
     H2Error(#[from] crate::h2::Error),
     #[error("IO error {0}")]
     IOError(#[from] std::io::Error),
+    // #[cfg(feature = "parsed")]
+    // #[error("Parse error {0}")]
+    // ParseError(#[from] ParseError),
 }
 
 impl From<Infallible> for HttpError {

--- a/monoio-http/src/common/error.rs
+++ b/monoio-http/src/common/error.rs
@@ -43,6 +43,9 @@ pub enum HttpError {
     #[cfg(feature = "parsed")]
     #[error("SerDe error {0}")]
     SerDeError(#[from] serde_urlencoded::de::Error),
+    #[cfg(feature = "parsed")]
+    #[error("Multer Error")]
+    MulterError(#[from] multer::Error),
 }
 
 impl From<Infallible> for HttpError {

--- a/monoio-http/src/common/error.rs
+++ b/monoio-http/src/common/error.rs
@@ -15,6 +15,7 @@ use crate::h1::{
 pub enum ExtractError {
     #[error("Uninitialized cookie jar")]
     UninitializedCookieJar,
+    #[cfg(feature = "parsed")]
     #[error("http cookie parsing error {0}")]
     CookieParseError(#[from] cookie::ParseError),
     #[error("Invalid Header Value")]
@@ -39,6 +40,7 @@ pub enum HttpError {
     IOError(#[from] std::io::Error),
     #[error("Cookie error {0}")]
     CookieError(#[from] ExtractError),
+    #[cfg(feature = "parsed")]
     #[error("SerDe error {0}")]
     SerDeError(#[from] serde_urlencoded::de::Error),
 }

--- a/monoio-http/src/common/parsed/mod.rs
+++ b/monoio-http/src/common/parsed/mod.rs
@@ -1,6 +1,7 @@
 //! For lazy parse request/response and modify headers.
 pub mod request;
 pub mod response;
+pub mod multipart;
 
 use std::collections::HashMap;
 

--- a/monoio-http/src/common/parsed/mod.rs
+++ b/monoio-http/src/common/parsed/mod.rs
@@ -1,7 +1,7 @@
 //! For lazy parse request/response and modify headers.
+pub mod multipart;
 pub mod request;
 pub mod response;
-pub mod multipart;
 
 use std::collections::HashMap;
 

--- a/monoio-http/src/common/parsed/multipart.rs
+++ b/monoio-http/src/common/parsed/multipart.rs
@@ -285,7 +285,7 @@ impl ParsedMultiPartForm {
 
 // Converts the ParsedMultiPartForm into a HttpBody stream by reconstructing the multipart form
 // body. The values which are small in size are returned first, followed by the file data which is
-// on the disk for every subsequent next_data call.  
+// on the disk for every subsequent next_data call.
 impl Body for ParsedMultiPartForm {
     type Data = Bytes;
     type Error = HttpError;

--- a/monoio-http/src/common/parsed/multipart.rs
+++ b/monoio-http/src/common/parsed/multipart.rs
@@ -1,0 +1,316 @@
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use bytes::{Bytes, BytesMut};
+use http::HeaderMap;
+use monoio::fs::File;
+
+use crate::common::{
+    body::{Body, HttpBody, StreamHint},
+    error::HttpError,
+};
+
+pub const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024; // 10 MB
+
+#[derive(Debug, Clone)]
+enum Data {
+    InMemory(Bytes),
+    InFile(PathBuf),
+}
+
+#[derive(Debug, Clone)]
+pub struct FileHeader {
+    filename: String,
+    headers: HeaderMap,
+    data: Data,
+}
+
+#[derive(Debug, Clone)]
+pub struct FieldHeader {
+    pub value: String,
+    pub headers: HeaderMap,
+}
+
+#[derive(Debug)]
+pub struct ParsedMultiPartForm {
+    value: HashMap<String, Vec<FieldHeader>>,
+    file: HashMap<String, Vec<FileHeader>>,
+    boundary: String,
+    first_part: bool,
+    closed: bool,
+    max_file_size: u64,
+}
+
+impl FieldHeader {
+    pub fn get_value(&self) -> String {
+        self.value.clone()
+    }
+
+    pub fn get_headers(&self) -> &HeaderMap {
+        &self.headers
+    }
+}
+
+impl FileHeader {
+    pub fn get_filename(&self) -> String {
+        self.filename.clone()
+    }
+
+    pub fn get_headers(&self) -> &HeaderMap {
+        &self.headers
+    }
+
+    pub fn get_file_path(&self) -> Option<PathBuf> {
+        match &self.data {
+            Data::InMemory(_) => None,
+            Data::InFile(file) => Some(file.clone()),
+        }
+    }
+}
+
+// impl From<ParsedMultiPartForm> for HttpBody {
+//     fn from(p: ParsedMultiPartForm) -> Self {
+//         Self::Multipart(p)
+//     }
+// }
+
+impl ParsedMultiPartForm {
+    pub fn new(boundary: String, max_file_size: u64) -> Self {
+        Self {
+            value: HashMap::new(),
+            file: HashMap::new(),
+            boundary,
+            first_part: true,
+            closed: false,
+            max_file_size,
+        }
+    }
+
+    fn insert_field_value(&mut self, key: String, value: String, headers: HeaderMap) {
+        self.value
+            .entry(key)
+            .or_default()
+            .push(FieldHeader { value, headers });
+    }
+
+    fn insert_file(&mut self, key: String, file: FileHeader) {
+        self.file.entry(key).or_default().push(file);
+    }
+
+    fn insert_file_data(&mut self, key: String, filename: String, headers: HeaderMap, data: Data) {
+        self.insert_file(
+            key,
+            FileHeader {
+                filename,
+                headers,
+                data,
+            },
+        );
+    }
+
+    pub fn get_field_value(&self, key: &str) -> Option<Vec<FieldHeader>> {
+        self.value.get(key).cloned()
+    }
+
+    pub fn get_file(&self, key: &str) -> Option<Vec<FileHeader>> {
+        self.file.get(key).map(|v| {
+            v.iter()
+                .map(|file| {
+                    let data = match &file.data {
+                        Data::InMemory(bytes) => Data::InMemory(bytes.clone()),
+                        Data::InFile(file) => Data::InFile(file.clone()),
+                    };
+                    FileHeader {
+                        filename: file.filename.clone(),
+                        headers: file.headers.clone(),
+                        data,
+                    }
+                })
+                .collect()
+        })
+    }
+
+    pub fn value_keys(&self) -> impl Iterator<Item = &String> {
+        self.value.keys()
+    }
+
+    pub fn file_keys(&self) -> impl Iterator<Item = &String> {
+        self.file.keys()
+    }
+
+    fn get_next_file_key(&self) -> Option<String> {
+        self.file.keys().next().cloned()
+    }
+
+    fn write_part(&mut self, mut buf: BytesMut, headers: HeaderMap) -> Result<BytesMut, HttpError> {
+        if !self.first_part {
+            buf.extend_from_slice(format!("\r\n--{}\r\n", self.boundary).as_bytes());
+        } else {
+            buf.extend_from_slice(format!("--{}\r\n", self.boundary).as_bytes());
+            self.first_part = false;
+        }
+
+        let mut keys = headers
+            .keys()
+            .map(|k| k.to_string())
+            .collect::<Vec<String>>();
+        keys.sort();
+
+        for key in keys {
+            let header_value = headers.get(&key.clone()).unwrap();
+            match header_value.to_str() {
+                Ok(value) => {
+                    buf.extend_from_slice(format!("{}: {}\r\n", key, value).as_bytes());
+                }
+                Err(_) => {
+                    buf.extend_from_slice(format!("{}: ", key).as_bytes());
+                    buf.extend_from_slice(header_value.as_bytes());
+                    buf.extend_from_slice("\r\n".to_string().as_bytes());
+                }
+            }
+        }
+
+        buf.extend_from_slice("\r\n".as_bytes());
+
+        Ok(buf)
+    }
+
+    fn write_forms(&mut self) -> Result<Option<Bytes>, HttpError> {
+        let mut buf = BytesMut::new();
+        let cloned_value = self.value.clone(); // Clone self.value outside of the loop
+        for (_, forms) in cloned_value.iter() {
+            for form in forms {
+                let headers = form.headers.clone(); // Store the value of form.headers in a separate variable
+                buf = self.write_part(buf, headers.clone())?;
+                buf.extend_from_slice(form.value.as_bytes());
+            }
+        }
+
+        self.value.clear();
+
+        Ok(Some(buf.freeze()))
+    }
+
+    async fn write_file(&mut self, key: String) -> Result<Option<Bytes>, HttpError> {
+        let mut buf = BytesMut::new();
+        for file in self.file.get(&key).unwrap().clone() {
+            buf = self.write_part(buf, file.headers.clone())?;
+
+            match &file.data {
+                Data::InMemory(bytes) => {
+                    buf.extend_from_slice(bytes.as_ref());
+                }
+                Data::InFile(file) => {
+                    let file = File::open(file).await?;
+                    let mut pos: u64 = 0;
+
+                    loop {
+                        let chunk = vec![0; 1024 * 1024]; // 1 KB chunk
+                        let (res, read_chunk) = file.read_at(chunk, pos).await;
+                        let bytes_written = res?;
+                        pos += bytes_written as u64;
+                        if bytes_written == 0 {
+                            break;
+                        }
+                        buf.extend_from_slice(&read_chunk[..bytes_written]);
+                    }
+                }
+            };
+        }
+
+        self.file.remove(&key);
+
+        Ok(Some(buf.freeze()))
+    }
+
+    fn close_multipart(&mut self) -> Result<Option<Bytes>, HttpError> {
+        let mut buf = BytesMut::new();
+        self.closed = true;
+        buf.extend_from_slice(format!("\r\n--{}--\r\n", self.boundary).as_bytes());
+        Ok(Some(buf.freeze()))
+    }
+
+    pub async fn read_form(
+        mut multer_multipart: multer::Multipart<'_>,
+        boundary: String,
+        max_file_size: u64,
+    ) -> Result<Self, HttpError> {
+        let mut form = ParsedMultiPartForm::new(boundary, max_file_size);
+        while let Some(mut field) = multer_multipart.next_field().await? {
+            let name = field.name().unwrap_or_default().to_string();
+            let file_name = field.file_name().unwrap_or("").to_string();
+            let headers = field.headers().clone();
+
+            if file_name.is_empty() {
+                let value = field.bytes().await?.to_vec();
+                let value = String::from_utf8_lossy(&value).to_string();
+                println!("name: {:?}, Value: {:?}", name, value);
+                form.insert_field_value(name, value, headers);
+                continue;
+            }
+
+            let timestamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
+
+            let path = format!("/tmp/{}_{}.txt", file_name, timestamp);
+            let file = monoio::fs::File::create(path.clone()).await?;
+            let mut pos: u64 = 0;
+
+            while let Some(bytes) = field.chunk().await? {
+                let (res, _) = file.write_at(bytes, pos).await;
+                pos += res? as u64;
+            }
+
+            let data = if pos < form.max_file_size {
+                let _ = file.close().await;
+                let buf = BytesMut::with_capacity(pos as usize);
+                let file = monoio::fs::File::open(path.clone()).await?;
+                let (res, ret_buf) = file.read_exact_at(buf, 0).await;
+                res?;
+                Data::InMemory(ret_buf.freeze())
+            } else {
+                Data::InFile(PathBuf::from(path))
+            };
+
+            form.insert_file_data(name, file_name, headers, data);
+        }
+
+        Ok(form)
+    }
+}
+
+impl Body for ParsedMultiPartForm {
+    type Data = Bytes;
+    type Error = HttpError;
+
+    async fn next_data(&mut self) -> Option<Result<Self::Data, Self::Error>> {
+        if !self.value.is_empty() {
+            return self
+                .write_forms()
+                .map_or_else(|e| Some(Err(e)), |v| v.map(Ok));
+        }
+
+        if let Some(key) = self.get_next_file_key() {
+            return self
+                .write_file(key)
+                .await
+                .map_or_else(|e| Some(Err(e)), |v| v.map(Ok));
+        }
+
+        if !self.closed && self.value.is_empty() && self.file.is_empty() {
+            return self
+                .close_multipart()
+                .map_or_else(|e| Some(Err(e)), |v| v.map(Ok));
+        }
+        None
+    }
+
+    fn stream_hint(&self) -> StreamHint {
+        StreamHint::Stream
+    }
+}

--- a/monoio-http/src/common/parsed/multipart.rs
+++ b/monoio-http/src/common/parsed/multipart.rs
@@ -71,11 +71,11 @@ impl FileHeader {
     }
 }
 
-// impl From<ParsedMultiPartForm> for HttpBody {
-//     fn from(p: ParsedMultiPartForm) -> Self {
-//         Self::Multipart(p)
-//     }
-// }
+impl From<ParsedMultiPartForm> for HttpBody {
+    fn from(p: ParsedMultiPartForm) -> Self {
+        Self::Multipart(p)
+    }
+}
 
 impl ParsedMultiPartForm {
     pub fn new(boundary: String, max_file_size: u64) -> Self {
@@ -247,7 +247,6 @@ impl ParsedMultiPartForm {
             if file_name.is_empty() {
                 let value = field.bytes().await?.to_vec();
                 let value = String::from_utf8_lossy(&value).to_string();
-                println!("name: {:?}, Value: {:?}", name, value);
                 form.insert_field_value(name, value, headers);
                 continue;
             }
@@ -284,6 +283,9 @@ impl ParsedMultiPartForm {
     }
 }
 
+// Converts the ParsedMultiPartForm into a HttpBody stream by reconstructing the multipart form
+// body. The values which are small in size are returned first, followed by the file data which is
+// on the disk for every subsequent next_data call.  
 impl Body for ParsedMultiPartForm {
     type Data = Bytes;
     type Error = HttpError;

--- a/monoio-http/src/common/parsed/multipart.rs
+++ b/monoio-http/src/common/parsed/multipart.rs
@@ -10,7 +10,7 @@ use monoio::fs::File;
 
 use crate::common::{
     body::{Body, HttpBody, StreamHint},
-    error::HttpError,
+    error::{ParseError, HttpError},
 };
 
 pub const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024; // 10 MB
@@ -237,7 +237,7 @@ impl ParsedMultiPartForm {
         mut multer_multipart: multer::Multipart<'_>,
         boundary: String,
         max_file_size: u64,
-    ) -> Result<Self, HttpError> {
+    ) -> Result<Self, ParseError> {
         let mut form = ParsedMultiPartForm::new(boundary, max_file_size);
         while let Some(mut field) = multer_multipart.next_field().await? {
             let name = field.name().unwrap_or_default().to_string();

--- a/monoio-http/src/common/parsed/request.rs
+++ b/monoio-http/src/common/parsed/request.rs
@@ -4,7 +4,7 @@ use bytes::{Bytes, BytesMut};
 use cookie::{Cookie, CookieJar};
 pub use http::request::{Builder as RequestBuilder, Parts as RequestHead};
 use http::{
-    header::{CONTENT_TYPE, COOKIE},
+    header::{CONTENT_LENGTH, CONTENT_TYPE, COOKIE, TRANSFER_ENCODING},
     Request,
 };
 use mime::{APPLICATION_WWW_FORM_URLENCODED, MULTIPART_FORM_DATA};
@@ -55,6 +55,8 @@ impl<P> ParsedRequest<P> {
     }
 }
 
+
+
 impl<P> ParsedRequest<P> {
     #[inline]
     pub fn cookies(&mut self) -> &mut Parse<CookieJar> {
@@ -74,28 +76,37 @@ impl<P> ParsedRequest<P> {
     }
 }
 
-impl<P: crate::common::body::FixedBody> From<ParsedRequest<P>> for Request<P> {
+impl<P: FixedBody + From<ParsedMultiPartForm>> From<ParsedRequest<P>> for Request<P> {
     #[inline]
     fn from(pr: ParsedRequest<P>) -> Self {
         pr.into_http_request()
     }
 }
 
-impl<P: crate::common::body::FixedBody> ParsedRequest<P> {
+impl<P: FixedBody + From<ParsedMultiPartForm>> ParsedRequest<P> {
     #[inline]
     pub fn into_http_request(mut self) -> Request<P> {
         self.serialize_cookies_into_header();
+        // Handle URL body encoding
         if let Some(body) = self.body_cache {
             let body = P::fixed_body(Some(body));
             let (parts, _) = self.inner.into_parts();
             let new_req = Request::from_parts(parts, body);
             return new_req;
         }
+        // Handle multipart form data
+        if self.multipart_params.is_parsed() {
+            // Multipart form data is transfered as a stream, chunked body for H1.
+            self.inner.headers_mut().remove(CONTENT_LENGTH);
+            let body = P::from(self.multipart_params.unwrap());
+            let (parts, _) = self.inner.into_parts(); 
+            return Request::from_parts(parts, body)
+        }
         self.inner
     }
 }
 
-impl<P: crate::common::body::FixedBody> IntoParts for ParsedRequest<P> {
+impl<P: FixedBody + From<ParsedMultiPartForm>> IntoParts for ParsedRequest<P> {
     type Parts = RequestHead;
     type Body = P;
     #[inline]
@@ -359,9 +370,15 @@ where
             return Err(ExtractError::Previous.into());
         }
 
-        let boundary = match self.inner.headers().get("Content-Type") {
+        println!("{:?}", self.inner.headers().get(CONTENT_TYPE));
+
+        let boundary = match self.inner.headers().get(CONTENT_TYPE) {
             Some(content_type)
-                if content_type.as_bytes()
+                if content_type
+                .to_str()
+                .ok()
+                .and_then(|s| s.split(';').next())
+                .unwrap_or_default().as_bytes()
                     == MULTIPART_FORM_DATA.as_ref().as_bytes() => {
                         content_type.to_str().ok().and_then(|s| s.split("boundary=").nth(1)).unwrap_or_default().to_string()
                     }
@@ -434,12 +451,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::io::{Cursor, Read};
+    use std::{io::Read, path::PathBuf};
 
     use http::header::HeaderValue;
 
     use super::*;
-    use crate::common::body::HttpBody;
+    use crate::common::body::{BodyExt, HttpBody};
 
     fn build_request_with_cookies() -> Request<HttpBody> {
         let body = HttpBody::fixed_body(None);
@@ -601,36 +618,6 @@ mod tests {
         request
     }
 
-    fn create_request_multi_part() -> Request<HttpBody> {
-        let mut multipart = multipart::client::lazy::Multipart::new();
-        multipart.add_text("field1", "value1");
-        multipart.add_text("field2", "value2");
-
-        let file_data = "Hello, World!".as_bytes();
-        let file_mime = Some(mime::TEXT_PLAIN);
-        multipart.add_stream(
-            "file",
-            Cursor::new(file_data),
-            Some("HelloWorld.txt"),
-            file_mime,
-        );
-
-        let mut p = multipart.prepare().unwrap();
-        let boundary = p.boundary();
-        let content_type = format!("multipart/form-data; boundary={}", boundary);
-        let mut buf = Vec::new();
-        p.read_to_end(&mut buf).unwrap();
-
-        let body = HttpBody::fixed_body(Some(Bytes::from(buf)));
-        let mut request = Request::new(body);
-        request.headers_mut().insert(
-            http::header::CONTENT_TYPE,
-            HeaderValue::from_str(content_type.as_str()).unwrap(),
-        );
-
-        request
-    }
-
     #[monoio::test_all]
     async fn test_request_url_encoded_body_parse() {
         use crate::common::body::BodyExt;
@@ -671,29 +658,122 @@ mod tests {
         );
     }
 
+    fn create_request_multi_part() -> Request<HttpBody> {
+        let body = b"--iYJaNWIc97YKxZYB\r\ncontent-disposition: form-data; name=\"field2\"\r\n\r\nvalue2\r\n--iYJaNWIc97YKxZYB\r\ncontent-disposition: form-data; name=\"field1\"\r\n\r\nvalue1\r\n--iYJaNWIc97YKxZYB\r\ncontent-disposition: form-data; name=\"file\"; filename=\"HelloWorld.txt\"\r\ncontent-type: text/plain\r\n\r\nHello, World!\nHello, World!\nHello, World!\nHello, World!\nHello, World!\nHello, World!\n\r\n--iYJaNWIc97YKxZYB--\r\n";
+
+        let boundary = "iYJaNWIc97YKxZYB";
+        let content_type = format!("multipart/form-data; boundary={}", boundary);
+        let body = HttpBody::fixed_body(Some(Bytes::from(body.to_vec())));
+        let mut request = Request::new(body);
+        request.headers_mut().insert(
+            http::header::CONTENT_TYPE,
+            HeaderValue::from_str(content_type.as_str()).unwrap(),
+        );
+
+        request
+    }
+
+    fn create_request_multi_part_files_only() -> Request<HttpBody> {
+        let body = b"--iYJaNWIc97YKxZYB\r\ncontent-disposition: form-data; name=\"file1\"; filename=\"File1.txt\"\r\ncontent-type: text/plain\r\n\r\nHello from world1.\r\n--iYJaNWIc97YKxZYB\r\ncontent-disposition: form-data; name=\"file2\"; filename=\"File2.txt\"\r\ncontent-type: text/plain\r\n\r\nHello from world2.\r\n--iYJaNWIc97YKxZYB--\r\n";
+        let boundary = "iYJaNWIc97YKxZYB";
+        let content_type = format!("multipart/form-data; boundary={}", boundary);
+        let body = HttpBody::fixed_body(Some(Bytes::from(body.to_vec())));
+        let mut request = Request::new(body);
+        request.headers_mut().insert(
+            http::header::CONTENT_TYPE,
+            HeaderValue::from_str(content_type.as_str()).unwrap(),
+        );
+
+        request
+    }
+
     #[monoio::test_all]
-    async fn test_request_multi_part_parse_async() {
+    async fn test_request_parsed_multipartform_to_body() {
         let request = create_request_multi_part();
+        let (part, body) = request.into_parts();
+        let mp_body_bytes_1 = body.bytes().await.unwrap();
+        let request =
+            Request::from_parts(part, HttpBody::fixed_body(Some(mp_body_bytes_1.clone())));
 
-        let parsed_request = ParsedRequest::new(request);
+        let mut parsed_request = ParsedRequest::new(request);
 
-        let mut multipart_struct = parsed_request.parse_multipart_async(None).unwrap();
+        parsed_request
+            .parse_multipart_params(None, None)
+            .await
+            .unwrap();
 
-        let field = multipart_struct.next_field().await.unwrap().unwrap();
-        assert_eq!(field.name().unwrap(), "field1");
-        let bytes = field.bytes().await.unwrap();
-        assert_eq!(bytes, Bytes::from_static(b"value1"));
+        let result = parsed_request
+            .get_multipart_field_param("field1")
+            .unwrap();
+        assert_eq!(result[0].value, "value1");
 
-        let field = multipart_struct.next_field().await.unwrap().unwrap();
-        assert_eq!(field.name().unwrap(), "field2");
-        let bytes = field.bytes().await.unwrap();
-        assert_eq!(bytes, Bytes::from_static(b"value2"));
+        let result = parsed_request
+            .get_multipart_field_param("field2")
+            .unwrap();
+        assert_eq!(result[0].value, "value2");
 
-        let field = multipart_struct.next_field().await.unwrap().unwrap();
-        assert_eq!(field.name().unwrap(), "file");
-        assert_eq!(field.file_name().unwrap(), "HelloWorld.txt".to_string());
-        assert_eq!(field.content_type().unwrap(), &mime::TEXT_PLAIN);
-        let bytes = field.bytes().await.unwrap();
-        assert_eq!(bytes, Bytes::from_static(b"Hello, World!"));
+        let req_mp = parsed_request.into_http_request();
+        let mp_converted_body_bytes = req_mp.into_body().bytes().await.unwrap();
+
+        // Order of fields can be different
+        let body = b"--iYJaNWIc97YKxZYB\r\ncontent-disposition: form-data; name=\"field1\"\r\n\r\nvalue1\r\n--iYJaNWIc97YKxZYB\r\ncontent-disposition: form-data; name=\"field2\"\r\n\r\nvalue2\r\n--iYJaNWIc97YKxZYB\r\ncontent-disposition: form-data; name=\"file\"; filename=\"HelloWorld.txt\"\r\ncontent-type: text/plain\r\n\r\nHello, World!\nHello, World!\nHello, World!\nHello, World!\nHello, World!\nHello, World!\n\r\n--iYJaNWIc97YKxZYB--\r\n";
+        let mp_body_bytes_2 = Bytes::from(body.to_vec());
+
+        assert!(
+            mp_converted_body_bytes == mp_body_bytes_1
+                || mp_converted_body_bytes == mp_body_bytes_2
+        );
+    }
+
+    fn read_file(path: PathBuf) -> Vec<u8> {
+        let mut file = std::fs::File::open(path).unwrap();
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf).unwrap();
+        buf
+    }
+
+    #[monoio::test_all]
+    async fn test_request_parsed_multipartform_files() {
+        let request = create_request_multi_part_files_only();
+        let (part, body) = request.into_parts();
+        let mp_body_bytes_1 = body.bytes().await.unwrap();
+        let request =
+            Request::from_parts(part, HttpBody::fixed_body(Some(mp_body_bytes_1.clone())));
+
+        let mut parsed_request = ParsedRequest::new(request);
+
+        // Restrict Max file size to 2 bytes, File will be stored on disk instead
+        // of in memory
+        parsed_request
+            .parse_multipart_params(None, Some(2))
+            .await
+            .unwrap();
+
+        let result = parsed_request
+            .get_multipart_file_param("file1")
+            .unwrap();
+
+        assert_eq!(result[0].get_filename(), "File1.txt");
+        let path = result[0].get_file_path().unwrap();
+        assert_eq!(&read_file(path), b"Hello from world1.");
+
+        let result = parsed_request
+            .get_multipart_file_param("file2")
+            .unwrap();
+        assert_eq!(result[0].get_filename(), "File2.txt");
+        let path = result[0].get_file_path().unwrap();
+        assert_eq!(&read_file(path), b"Hello from world2.");
+
+        let req_mp = parsed_request.into_http_request();
+        let mp_converted_body_bytes = req_mp.into_body().bytes().await.unwrap();
+
+        // Order of fields can be different
+        let body = b"--iYJaNWIc97YKxZYB\r\ncontent-disposition: form-data; name=\"file2\"; filename=\"File2.txt\"\r\ncontent-type: text/plain\r\n\r\nHello from world2.\r\n--iYJaNWIc97YKxZYB\r\ncontent-disposition: form-data; name=\"file1\"; filename=\"File1.txt\"\r\ncontent-type: text/plain\r\n\r\nHello from world1.\r\n--iYJaNWIc97YKxZYB--\r\n";
+        let mp_body_bytes_2 = Bytes::from(body.to_vec());
+
+        assert!(
+            mp_converted_body_bytes == mp_body_bytes_1
+                || mp_converted_body_bytes == mp_body_bytes_2
+        );
     }
 }

--- a/monoio-http/src/common/parsed/request.rs
+++ b/monoio-http/src/common/parsed/request.rs
@@ -7,7 +7,7 @@ use http::{
     header::{CONTENT_TYPE, COOKIE},
     Request,
 };
-use mime::APPLICATION_WWW_FORM_URLENCODED;
+use mime::{APPLICATION_WWW_FORM_URLENCODED, MULTIPART_FORM_DATA};
 
 use crate::common::{
     body::{Body, FixedBody, HttpBodyStream, StreamHint},
@@ -16,11 +16,14 @@ use crate::common::{
     IntoParts,
 };
 
+use super::multipart::{FieldHeader, FileHeader, ParsedMultiPartForm};
+
 pub struct ParsedRequest<P> {
     inner: Request<P>,
     cookie_jar: UnsafeCell<Parse<CookieJar>>,
     url_params: UnsafeCell<Parse<QueryMap>>,
     body_form_params: Parse<QueryMap>,
+    multipart_params: Parse<ParsedMultiPartForm>, 
     body_cache: Option<Bytes>,
 }
 
@@ -32,6 +35,7 @@ impl<P> From<Request<P>> for ParsedRequest<P> {
             cookie_jar: UnsafeCell::new(Parse::Unparsed),
             url_params: UnsafeCell::new(Parse::Unparsed),
             body_form_params: Parse::Unparsed,
+            multipart_params: Parse::Unparsed,
             body_cache: None,
         }
     }
@@ -45,6 +49,7 @@ impl<P> ParsedRequest<P> {
             cookie_jar: UnsafeCell::new(Parse::Unparsed),
             url_params: UnsafeCell::new(Parse::Unparsed),
             body_form_params: Parse::Unparsed,
+            multipart_params: Parse::Unparsed,
             body_cache: None,
         }
     }
@@ -327,6 +332,102 @@ where
             }
         } else {
             Err(ExtractError::InvalidHeaderValue.into())
+        }
+    }
+}
+
+
+impl<P> ParsedRequest<P>
+where
+    P: Into<HttpBodyStream> + 'static + FixedBody,
+{
+    /// See https://docs.rs/multer/latest/multer/struct.Constraints.html for constraints. 
+    /// Size limits for whole stream body, per field, allowed fields etc.
+    /// Any field with a file size greater than max_file_size will be stored on disk.
+    /// Default max_file_size is 10MB.
+    pub async fn parse_multipart_params<'a>(
+        &mut self,
+        user_constraints: Option<multer::Constraints>,
+        max_file_size: Option<u64>,
+    ) -> Result<&mut ParsedMultiPartForm, HttpError> {
+
+        if self.multipart_params.is_parsed() {
+            return Ok(unsafe { self.multipart_params.as_mut().unwrap_unchecked() });
+        }
+
+        if self.multipart_params.is_failed() {
+            return Err(ExtractError::Previous.into());
+        }
+
+        let boundary = match self.inner.headers().get("Content-Type") {
+            Some(content_type)
+                if content_type.as_bytes()
+                    == MULTIPART_FORM_DATA.as_ref().as_bytes() => {
+                        content_type.to_str().ok().and_then(|s| s.split("boundary=").nth(1)).unwrap_or_default().to_string()
+                    }
+            _ => {
+                self.multipart_params = Parse::Failed;
+                return Err(ExtractError::InvalidContentType.into());
+            }
+        };
+
+        let body = std::mem::replace(self.inner.body_mut(), P::fixed_body(None));
+        let body_stream: HttpBodyStream = body.into();
+
+        let constraints_to_use = user_constraints.unwrap_or_default();
+        let multer = multer::Multipart::with_constraints(
+            body_stream,
+            boundary.clone(),
+            constraints_to_use,
+        );
+
+        let max_file_size = max_file_size.unwrap_or(super::multipart::MAX_FILE_SIZE);
+
+        let parsed_multi_part =
+            ParsedMultiPartForm::read_form(multer, boundary, max_file_size).await?;
+
+        self.multipart_params = Parse::Parsed(parsed_multi_part);
+
+        Ok(unsafe { self.multipart_params.as_mut().unwrap_unchecked() })
+    }
+
+    pub async fn parse_get_multipart_field_param(&mut self, name: &str) -> Result<Option<Vec<FieldHeader>>, HttpError> {
+        self.parse_multipart_params(None, None).await?;
+        Ok(unsafe { self.multipart_params.as_mut().unwrap_unchecked() }
+            .get_field_value(name))
+    }
+
+    pub fn get_multipart_field_param(&self, name: &str) -> Option<Vec<FieldHeader>> {
+        match self.multipart_params {
+            Parse::Parsed(ref map) => map.get_field_value(name),
+            _ => None,
+        }
+    }
+
+    pub async fn parse_get_multipart_file_param(&mut self, name: &str) -> Result<Option<Vec<FileHeader>>, HttpError> {
+        self.parse_multipart_params(None, None).await?;
+        Ok(unsafe { self.multipart_params.as_mut().unwrap_unchecked() }
+            .get_file(name))
+    }
+
+    pub fn get_multipart_file_param(&self, name: &str) -> Option<Vec<FileHeader>> {
+        match self.multipart_params {
+            Parse::Parsed(ref map) => map.get_file(name),
+            _ => None,
+        }
+    }
+
+    pub fn get_multipart_value_keys(&self) -> Option<impl Iterator<Item = &String>> {
+        match &self.multipart_params {
+            Parse::Parsed(ref map) => Some(map.value_keys()),
+            _ => None 
+        }
+    }
+
+    pub fn get_multipart_file_keys(&self) -> Option<impl Iterator<Item = &String>> {
+        match &self.multipart_params {
+            Parse::Parsed(ref map) => Some(map.file_keys()),
+            _ =>  None
         }
     }
 }

--- a/monoio-http/src/common/parsed/request.rs
+++ b/monoio-http/src/common/parsed/request.rs
@@ -382,13 +382,13 @@ where
         &mut self,
         user_constraints: Option<multer::Constraints>,
         max_file_size: Option<u64>,
-    ) -> Result<&mut ParsedMultiPartForm, HttpError> {
+    ) -> Result<&mut ParsedMultiPartForm, ParseError> {
         if self.multipart_params.is_parsed() {
             return Ok(unsafe { self.multipart_params.as_mut().unwrap_unchecked() });
         }
 
         if self.multipart_params.is_failed() {
-            return Err(ExtractError::Previous.into());
+            return Err(ParseError::Previous.into());
         }
 
         println!("{:?}", self.inner.headers().get(CONTENT_TYPE));
@@ -412,7 +412,7 @@ where
             }
             _ => {
                 self.multipart_params = Parse::Failed;
-                return Err(ExtractError::InvalidContentType.into());
+                return Err(ParseError::InvalidContentType.into());
             }
         };
 
@@ -436,7 +436,7 @@ where
     pub async fn parse_get_multipart_field_param(
         &mut self,
         name: &str,
-    ) -> Result<Option<Vec<FieldHeader>>, HttpError> {
+    ) -> Result<Option<Vec<FieldHeader>>, ParseError> {
         self.parse_multipart_params(None, None).await?;
         Ok(unsafe { self.multipart_params.as_mut().unwrap_unchecked() }.get_field_value(name))
     }
@@ -451,7 +451,7 @@ where
     pub async fn parse_get_multipart_file_param(
         &mut self,
         name: &str,
-    ) -> Result<Option<Vec<FileHeader>>, HttpError> {
+    ) -> Result<Option<Vec<FileHeader>>, ParseError> {
         self.parse_multipart_params(None, None).await?;
         Ok(unsafe { self.multipart_params.as_mut().unwrap_unchecked() }.get_file(name))
     }

--- a/monoio-http/src/h2/share.rs
+++ b/monoio-http/src/h2/share.rs
@@ -477,7 +477,9 @@ impl Body for RecvStream {
     async fn next_data(&mut self) -> Option<Result<Self::Data, Self::Error>> {
         self.data().await.map(|res| {
             res.and_then(|bytes| {
-                self.flow_control().release_capacity(bytes.len()).map(|_| bytes)
+                self.flow_control()
+                    .release_capacity(bytes.len())
+                    .map(|_| bytes)
             })
         })
     }


### PR DESCRIPTION
- `ParsedMultipartFrom` follows https://pkg.go.dev/mime/multipart#Form API
- Files greater in size than 10MB are written to disk instead of being held in memory. Max file size configurable
- `into_multipart_body_request`: `ParsedMultipartFrom` to `HttpBody`
- Added two test cases to demonstrate usage
- Removed `Multipart ` crate, using multer exclusively now