### PR TITLE
Feat: Expose H2 conn state for monoio-transport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["monoio-http", "monoio-http-client"]
 resolver = "2"
 
 [workspace.dependencies]
-monoio = "0.2.0"
+monoio = "0.2.3"
 monoio-compat = "0.2.0"
 service-async = "0.2.0"
 monoio-rustls = "0.3.0"

--- a/monoio-http/Cargo.toml
+++ b/monoio-http/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 keywords = ["monoio", "http", "async"]
 license = "MIT/Apache-2.0"
 name = "monoio-http"
-version = "0.3.7"
+version = "0.3.8"
 
 [dependencies]
 monoio = { workspace = true }

--- a/monoio-http/src/h1/codec/encoder.rs
+++ b/monoio-http/src/h1/codec/encoder.rs
@@ -294,6 +294,8 @@ impl Encoder<&[u8]> for FixedBodyEncoder {
     }
 }
 
+
+#[allow(dead_code)]
 struct ChunkedBodyEncoder;
 
 impl Encoder<Option<&[u8]>> for ChunkedBodyEncoder {

--- a/monoio-http/src/h2/client.rs
+++ b/monoio-http/src/h2/client.rs
@@ -147,7 +147,7 @@ use bytes::{Buf, Bytes};
 use http::{uri, HeaderMap, Method, Request, Response, Version};
 use monoio::io::{AsyncReadRent, AsyncWriteRent, AsyncWriteRentExt};
 use tracing::Instrument;
-
+use crate::common::error::HttpError;
 use crate::h2::{
     codec::{Codec, SendError, UserError},
     ext::Protocol,
@@ -536,6 +536,14 @@ where
     pub fn is_extended_connect_protocol_enabled(&self) -> bool {
         self.inner.is_extended_connect_protocol_enabled()
     }
+
+    pub fn has_conn_error(&self) -> bool {
+        self.inner.has_conn_error()
+    }
+
+    pub fn conn_error(&self) -> Option<HttpError> {
+        self.inner.conn_error().map(HttpError::from)
+    }
 }
 
 impl<B> fmt::Debug for SendRequest<B>
@@ -559,7 +567,6 @@ where
     }
 }
 
-#[cfg(feature = "unstable")]
 impl<B> SendRequest<B>
 where
     B: Buf,

--- a/monoio-http/src/h2/proto/streams/store.rs
+++ b/monoio-http/src/h2/proto/streams/store.rs
@@ -199,12 +199,10 @@ impl ops::IndexMut<Key> for Store {
 }
 
 impl Store {
-    #[cfg(feature = "unstable")]
     pub fn num_active_streams(&self) -> usize {
         self.ids.len()
     }
 
-    #[cfg(feature = "unstable")]
     pub fn num_wired_streams(&self) -> usize {
         self.slab.len()
     }

--- a/monoio-http/src/h2/proto/streams/streams.rs
+++ b/monoio-http/src/h2/proto/streams/streams.rs
@@ -948,7 +948,6 @@ where
         me.counts.max_recv_streams()
     }
 
-    #[cfg(feature = "unstable")]
     pub fn num_active_streams(&self) -> usize {
         let me = unsafe { &mut *self.inner.get() };
         me.store.num_active_streams()
@@ -964,10 +963,19 @@ where
         me.counts.has_streams() || me.refs > 1
     }
 
-    #[cfg(feature = "unstable")]
     pub fn num_wired_streams(&self) -> usize {
         let me = unsafe { &mut *self.inner.get() };
         me.store.num_wired_streams()
+    }
+
+    pub fn has_conn_error(&self) -> bool {
+        let me = unsafe { &mut *self.inner.get() };
+        me.actions.conn_error.is_some()
+    }
+
+    pub fn conn_error(&self) -> Option<crate::h2::Error> {
+        let me = unsafe { &mut *self.inner.get() };
+        me.actions.conn_error.clone().map(Into::into)
     }
 }
 


### PR DESCRIPTION
- Exposing stream count, connection state
- Required to implement client in monoio-transports
- bump up version